### PR TITLE
Swagger 적용 및 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
+
     // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/src/main/java/com/zelusik/eatery/app/config/SwaggerConfig.java
+++ b/src/main/java/com/zelusik/eatery/app/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package com.zelusik.eatery.app.config;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI eateryApi(@Value("eatery.app.version") String appVersion) {
+        // TODO: 로그인 기능 구현 후 Swagger에서 access-token을 header에 첨부할 수 있도록 security scheme component 추가 필요.
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("Eatery API Docs")
+                                .description("DND 8기 2조 앱 프로젝트 Reet-Place의 API 명세서")
+                                .version(appVersion)
+                )
+                .externalDocs(
+                        new ExternalDocumentation()
+                                .description("Github organization of team zelusik")
+                                .url("https://github.com/Zelusik")
+                );
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #5

## 🏃‍ Task
- Swagger 의존성 추가 및 API 명세서 설정 작성
  - Swagger-ui 페이지에 접근할 때 대량의 html 내용이 로그에 찍히는 것을 보고 조치함. Swagger-ui 관련한 요청/응답은 로그에 남지 않음.
  - SpringSecurity에 Swagger 관련 문서 접근을 허용하도록 설정 추가 및 일부 코드 변경 (BASE_URL을 활용하도록)

## 📄 Reference
- [Springdoc-openapi 공식문서](https://springdoc.org/)

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
