### PR TITLE
리뷰 생성 시 리뷰 키워드 요청 데이터 형식 변경

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/config/WebMvcConfig.java
+++ b/src/main/java/com/zelusik/eatery/app/config/WebMvcConfig.java
@@ -1,0 +1,15 @@
+package com.zelusik.eatery.app.config;
+
+import com.zelusik.eatery.app.util.ReviewKeywordRequestConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new ReviewKeywordRequestConverter());
+    }
+}

--- a/src/main/java/com/zelusik/eatery/app/domain/constant/ReviewKeyword.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/constant/ReviewKeyword.java
@@ -1,8 +1,11 @@
 package com.zelusik.eatery.app.domain.constant;
 
+import com.zelusik.eatery.global.exception.review.NotAcceptableReviewKeyword;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.Arrays;
 
 @Schema(
         description = "<p>리뷰 키워드. 목록은 다음과 같다</p>" +
@@ -39,4 +42,11 @@ public enum ReviewKeyword {
     ;
 
     private final String description;
+
+    public static ReviewKeyword valueOfDescription(String description) {
+        return Arrays.stream(values())
+                .filter(value -> description.equals(value.getDescription()))
+                .findFirst()
+                .orElseThrow(NotAcceptableReviewKeyword::new);
+    }
 }

--- a/src/main/java/com/zelusik/eatery/app/dto/review/response/ReviewResponse.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/review/response/ReviewResponse.java
@@ -24,7 +24,7 @@ public class ReviewResponse {
     private PlaceResponse place;
 
     @Schema(description = "리뷰 키워드 목록", example = "[\"FRESH\", \"NOISY\"]")
-    private List<ReviewKeyword> keywords;
+    private List<String> keywords;
 
     @Schema(description = "내용", example = "미래에 제가 살 곳은 여기로 정했습니다. 고기를 주문하면 ...")
     private String content;
@@ -32,7 +32,7 @@ public class ReviewResponse {
     @Schema(description = "리뷰에 첨부된 이미지 파일 목록")
     private List<ReviewFileResponse> reviewFiles;
 
-    public static ReviewResponse of(Long id, Long writerId, PlaceResponse place, List<ReviewKeyword> keywords, String content, List<ReviewFileResponse> reviewFiles) {
+    public static ReviewResponse of(Long id, Long writerId, PlaceResponse place, List<String> keywords, String content, List<ReviewFileResponse> reviewFiles) {
         return new ReviewResponse(id, writerId, place, keywords, content, reviewFiles);
     }
 
@@ -41,7 +41,9 @@ public class ReviewResponse {
                 reviewDto.id(),
                 reviewDto.writerDto().id(),
                 PlaceResponse.from(reviewDto.placeDto()),
-                reviewDto.keywords(),
+                reviewDto.keywords().stream()
+                        .map(ReviewKeyword::getDescription)
+                        .toList(),
                 reviewDto.content(),
                 reviewDto.reviewFileDtos().stream()
                         .map(ReviewFileResponse::from)

--- a/src/main/java/com/zelusik/eatery/app/util/ReviewKeywordRequestConverter.java
+++ b/src/main/java/com/zelusik/eatery/app/util/ReviewKeywordRequestConverter.java
@@ -1,0 +1,12 @@
+package com.zelusik.eatery.app.util;
+
+import com.zelusik.eatery.app.domain.constant.ReviewKeyword;
+import org.springframework.core.convert.converter.Converter;
+
+public class ReviewKeywordRequestConverter implements Converter<String, ReviewKeyword> {
+
+    @Override
+    public ReviewKeyword convert(String description) {
+        return ReviewKeyword.valueOfDescription(description);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/global/exception/ExceptionType.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/ExceptionType.java
@@ -1,6 +1,7 @@
 package com.zelusik.eatery.global.exception;
 
 import com.zelusik.eatery.app.domain.Member;
+import com.zelusik.eatery.app.domain.Review;
 import com.zelusik.eatery.app.domain.place.Place;
 import com.zelusik.eatery.global.exception.auth.RedisRefreshTokenNotFoundException;
 import com.zelusik.eatery.global.exception.auth.TokenValidateException;
@@ -8,6 +9,7 @@ import com.zelusik.eatery.global.exception.constant.ValidationErrorCode;
 import com.zelusik.eatery.global.exception.file.MultipartFileNotReadableException;
 import com.zelusik.eatery.global.exception.member.MemberIdNotFoundException;
 import com.zelusik.eatery.global.exception.place.PlaceNotFoundException;
+import com.zelusik.eatery.global.exception.review.NotAcceptableReviewKeyword;
 import com.zelusik.eatery.global.exception.scraping.OpeningHoursUnexpectedFormatException;
 import com.zelusik.eatery.global.exception.scraping.ScrapingServerInternalError;
 import com.zelusik.eatery.global.log.LogUtils;
@@ -47,7 +49,8 @@ import java.util.Optional;
  *     <li>14XX: DB 관련 예외</li>
  *     <li>15XX: 인증 관련 예외</li>
  *     <li>2XXX: 회원({@link Member}) 관련 예외</li>
- *     <li>3XXX: 장소 관련 예외</li>
+ *     <li>3000 ~ 3499: 장소 관련 예외</li>
+ *     <li>3500 ~ 3999: 리뷰 관련 예외</li>
  * </ul>
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -114,6 +117,11 @@ public enum ExceptionType {
      */
     OPENING_HOURS_UNEXPECTED_FORMAT(3000, "가게 영업시간이 처리할 수 없는 형태입니다. 서버 관리자에게 문의해주세요.게", OpeningHoursUnexpectedFormatException.class),
     PLACE_NOT_FOUND(3001, "가게를 찾을 수 없습니다.", PlaceNotFoundException.class),
+
+    /**
+     * 리뷰({@link Review}) 관련 예외
+     */
+    NOT_ACCEPTABLE_REVIEW_KEYWORD(3500, "유효하지 않은 리뷰 키워드입니다.", NotAcceptableReviewKeyword.class),
     ;
 
     private final Integer code;

--- a/src/main/java/com/zelusik/eatery/global/exception/review/NotAcceptableReviewKeyword.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/review/NotAcceptableReviewKeyword.java
@@ -1,0 +1,6 @@
+package com.zelusik.eatery.global.exception.review;
+
+import com.zelusik.eatery.global.exception.common.BadRequestException;
+
+public class NotAcceptableReviewKeyword extends BadRequestException {
+}

--- a/src/test/java/com/zelusik/eatery/app/controller/ReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/app/controller/ReviewControllerTest.java
@@ -74,7 +74,7 @@ class ReviewControllerTest {
                                 .param("place.roadAddress", reviewCreateRequest.getPlace().getRoadAddress())
                                 .param("place.lat", reviewCreateRequest.getPlace().getLat())
                                 .param("place.lng", reviewCreateRequest.getPlace().getLng())
-                                .param("keywords", "NOISY", "FRESH")
+                                .param("keywords", "신선한 재료", "왁자지껄한")
                                 .param("autoCreatedContent", reviewCreateRequest.getAutoCreatedContent())
                                 .param("content", reviewCreateRequest.getContent())
                                 .with(csrf())


### PR DESCRIPTION
기존, enum constants를 주고받던 상황에서 description 값(한글)로 요청/응답을 주고받도록 변경하였음.

## 🔥 Related Issue
- Close #16 

## 🏃‍ Task
- 리뷰 요청/응답 데이터 형식 변경
  - 수정 전: keywords: ["FRESH", "NOISY"]
  - 수정 후: keywords: ["신선한 재료", "왁자지껄한"]

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
