### PR TITLE
리뷰 키워드 응답 데이터 형식 변경

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/dto/review/response/ReviewListResponse.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/review/response/ReviewListResponse.java
@@ -1,7 +1,6 @@
 package com.zelusik.eatery.app.dto.review.response;
 
 import com.zelusik.eatery.app.domain.constant.ReviewKeyword;
-import com.zelusik.eatery.app.dto.place.response.PlaceResponse;
 import com.zelusik.eatery.app.dto.review.ReviewDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -20,7 +19,7 @@ public class ReviewListResponse {
     private Long writerId;
 
     @Schema(description = "리뷰 키워드 목록", example = "[\"FRESH\", \"NOISY\"]")
-    private List<ReviewKeyword> keywords;
+    private List<String> keywords;
 
     @Schema(description = "내용", example = "미래에 제가 살 곳은 여기로 정했습니다. 고기를 주문하면 ...")
     private String content;
@@ -28,7 +27,7 @@ public class ReviewListResponse {
     @Schema(description = "리뷰에 첨부된 이미지 파일 목록")
     private List<ReviewFileResponse> reviewFiles;
 
-    public static ReviewListResponse of(Long id, Long writerId, List<ReviewKeyword> keywords, String content, List<ReviewFileResponse> reviewFiles) {
+    public static ReviewListResponse of(Long id, Long writerId, List<String> keywords, String content, List<ReviewFileResponse> reviewFiles) {
         return new ReviewListResponse(id, writerId, keywords, content, reviewFiles);
     }
 
@@ -36,7 +35,9 @@ public class ReviewListResponse {
         return of(
                 dto.id(),
                 dto.writerDto().id(),
-                dto.keywords(),
+                dto.keywords().stream()
+                        .map(ReviewKeyword::getDescription)
+                        .toList(),
                 dto.content(),
                 dto.reviewFileDtos().stream()
                         .map(ReviewFileResponse::from)


### PR DESCRIPTION
## 🔥 Related Issue
- Close #16 

## 🏃‍ Task
- 리뷰 목록 응답 시 응답하는 리뷰 키워드 정보도 enum constants 값이 아닌 description 값이 응답되도록 변경. 4039640 에서 함께 수정됐어야 했던 내용인데, 누락되어 추가하였음.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
