### PR TITLE
multipart/form-data 형식의 요청에 대해 request/response 로그를 정상적으로 출력하지 못하는 버그 fix

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/config/WebFilterConfig.java
+++ b/src/main/java/com/zelusik/eatery/app/config/WebFilterConfig.java
@@ -1,0 +1,29 @@
+package com.zelusik.eatery.app.config;
+
+import com.zelusik.eatery.global.log.filter.LogApiInfoFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.Filter;
+
+@Configuration
+public class WebFilterConfig {
+
+    /**
+     * <p>
+     * API 요청/응답에 대한 로그를 출력하는 filter.
+     *
+     * <p>
+     * Spring Security에서 사용하는 filter 이전에 적용시키기 위해 Filter의 순서를 -101로 설정하였음.
+     * (Spring Security filter의 기본 순서는 -100)
+     */
+    @Bean
+    public FilterRegistrationBean<Filter> logFilter() {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new LogApiInfoFilter());
+        filterRegistrationBean.setOrder(-101);
+        filterRegistrationBean.addUrlPatterns("/*");
+        return filterRegistrationBean;
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #19

## 🏃‍ Task
- multipart/form-data 형식의 요청에 대해 로그가 정상적으로 출력되지 않는 버그 fix
  - (예상) multipart file의 경우 `MultipartHttpServletRequest`로 요청을 받아야 한다고 한다. 로그를 출력하기 위해 `RequestWrapper`로 request를 변환하면서 file이 손상되거나 누락되는 것 같음.
- access token 검증 시 로그에 log trace id가 찍히지 않는 버그 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
