### PR TITLE
Kakao 통신 관련 예외 처리 로직 세분화

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/controller/PlaceController.java
+++ b/src/main/java/com/zelusik/eatery/app/controller/PlaceController.java
@@ -28,7 +28,7 @@ public class PlaceController {
     )
     @ApiResponses({
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = PlaceResponse.class))),
-            @ApiResponse(description = "3001: 찾고자 하는 가게가 존재하지 않는 경우", responseCode = "404", content = @Content)
+            @ApiResponse(description = "[3001] 찾고자 하는 가게가 존재하지 않는 경우", responseCode = "404", content = @Content)
     })
     @GetMapping("/{placeId}")
     public PlaceResponse find(@PathVariable Long placeId) {

--- a/src/main/java/com/zelusik/eatery/app/controller/ReviewController.java
+++ b/src/main/java/com/zelusik/eatery/app/controller/ReviewController.java
@@ -43,9 +43,9 @@ public class ReviewController {
     )
     @ApiResponses({
             @ApiResponse(description = "Created", responseCode = "201", content = @Content(schema = @Schema(implementation = ReviewResponse.class))),
-            @ApiResponse(description = "1001: 전달받은 파일을 읽을 수 없는 경우.", responseCode = "400", content = @Content),
-            @ApiResponse(description = "1350: 장소에 대한 추가 정보를 스크래핑 할 Flask 서버에서 에러가 발생한 경우.", responseCode = "500", content = @Content),
-            @ApiResponse(description = "3000: 상세 페이지에서 읽어온 가게 영업시간이 처리할 수 없는 형태일 경우.", responseCode = "500", content = @Content)
+            @ApiResponse(description = "[1001] 전달받은 파일을 읽을 수 없는 경우.", responseCode = "400", content = @Content),
+            @ApiResponse(description = "[1350] 장소에 대한 추가 정보를 스크래핑 할 Flask 서버에서 에러가 발생한 경우.", responseCode = "500", content = @Content),
+            @ApiResponse(description = "[3000] 상세 페이지에서 읽어온 가게 영업시간이 처리할 수 없는 형태일 경우.", responseCode = "500", content = @Content)
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ReviewResponse> create(

--- a/src/main/java/com/zelusik/eatery/global/exception/CustomException.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/CustomException.java
@@ -12,7 +12,7 @@ public abstract class CustomException extends RuntimeException {
     private final Throwable cause;
 
     public CustomException(HttpStatus httpStatus) {
-        ExceptionType exceptionType = ExceptionType.from(this.getClass());
+        ExceptionType exceptionType = ExceptionType.from(this.getClass()).orElse(ExceptionType.UNHANDLED);
         this.httpStatus = httpStatus;
         this.code = exceptionType.getCode();
         this.message = exceptionType.getMessage();
@@ -20,7 +20,7 @@ public abstract class CustomException extends RuntimeException {
     }
 
     public CustomException(HttpStatus httpStatus, String optionalMessage) {
-        ExceptionType exceptionType = ExceptionType.from(this.getClass());
+        ExceptionType exceptionType = ExceptionType.from(this.getClass()).orElse(ExceptionType.UNHANDLED);
         this.httpStatus = httpStatus;
         this.code = exceptionType.getCode();
         this.message = exceptionType.getMessage() + " " + optionalMessage;
@@ -28,7 +28,7 @@ public abstract class CustomException extends RuntimeException {
     }
 
     public CustomException(HttpStatus httpStatus, Throwable cause) {
-        ExceptionType exceptionType = ExceptionType.from(this.getClass());
+        ExceptionType exceptionType = ExceptionType.from(this.getClass()).orElse(ExceptionType.UNHANDLED);
         this.httpStatus = httpStatus;
         this.code = exceptionType.getCode();
         this.message = exceptionType.getMessage();
@@ -36,7 +36,7 @@ public abstract class CustomException extends RuntimeException {
     }
 
     public CustomException(HttpStatus httpStatus, String optionalMessage, Throwable cause) {
-        ExceptionType exceptionType = ExceptionType.from(this.getClass());
+        ExceptionType exceptionType = ExceptionType.from(this.getClass()).orElse(ExceptionType.UNHANDLED);
         this.httpStatus = httpStatus;
         this.code = exceptionType.getCode();
         this.message = exceptionType.getMessage() + " " + optionalMessage;

--- a/src/main/java/com/zelusik/eatery/global/exception/ExceptionType.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/ExceptionType.java
@@ -7,6 +7,7 @@ import com.zelusik.eatery.global.exception.auth.RedisRefreshTokenNotFoundExcepti
 import com.zelusik.eatery.global.exception.auth.TokenValidateException;
 import com.zelusik.eatery.global.exception.constant.ValidationErrorCode;
 import com.zelusik.eatery.global.exception.file.MultipartFileNotReadableException;
+import com.zelusik.eatery.global.exception.kakao.KakaoTokenValidateException;
 import com.zelusik.eatery.global.exception.member.MemberIdNotFoundException;
 import com.zelusik.eatery.global.exception.place.PlaceNotFoundException;
 import com.zelusik.eatery.global.exception.review.NotAcceptableReviewKeyword;
@@ -51,6 +52,7 @@ import java.util.Optional;
  *     <li>2XXX: 회원({@link Member}) 관련 예외</li>
  *     <li>3000 ~ 3499: 장소 관련 예외</li>
  *     <li>3500 ~ 3999: 리뷰 관련 예외</li>
+ *     <li>1XXXX: Kakao server 관련 예외</li>
  * </ul>
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -122,13 +124,20 @@ public enum ExceptionType {
      * 리뷰({@link Review}) 관련 예외
      */
     NOT_ACCEPTABLE_REVIEW_KEYWORD(3500, "유효하지 않은 리뷰 키워드입니다.", NotAcceptableReviewKeyword.class),
+
+
+    /**
+     * Kakao server 관련 예외
+     */
+    KAKAO_SERVER(10000, "카카오 서버와의 통신에서 에러가 발생했습니다.", null),
+    KAKAO_TOKEN_VALIDATE(10000, "유효하지 않은 kakao access token입니다. 요청 데이터가 잘못 되었거나 토큰이 만료되지 않았는지 확인해주세요.", KakaoTokenValidateException.class),
     ;
 
     private final Integer code;
     private final String message;
     private final Class<? extends Exception> type;
 
-    public static ExceptionType from(Class<? extends Exception> classType) {
+    public static Optional<ExceptionType> from(Class<? extends Exception> classType) {
         Optional<ExceptionType> exceptionType = Arrays.stream(values())
                 .filter(ex -> ex.getType() != null && ex.getType().equals(classType))
                 .findFirst();
@@ -137,6 +146,6 @@ public enum ExceptionType {
             log.error("[{}] 정의되지 않은 exception이 발생하였습니다. Type of exception={}", LogUtils.getLogTraceId(), classType);
         }
 
-        return exceptionType.orElse(UNHANDLED);
+        return exceptionType;
     }
 }

--- a/src/main/java/com/zelusik/eatery/global/exception/kakao/KakaoServerException.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/kakao/KakaoServerException.java
@@ -1,0 +1,22 @@
+package com.zelusik.eatery.global.exception.kakao;
+
+import com.zelusik.eatery.global.exception.ExceptionType;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class KakaoServerException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+    private final Throwable cause;
+
+    public KakaoServerException(HttpStatus httpStatus, Integer errorCode, String errorMessage, Throwable cause) {
+        ExceptionType exceptionType = ExceptionType.from(this.getClass()).orElse(ExceptionType.KAKAO_SERVER);
+        this.httpStatus = httpStatus;
+        this.code = exceptionType.getCode() + errorCode;
+        this.message = exceptionType.getMessage() + " " + errorMessage;
+        this.cause = cause;
+    }
+}

--- a/src/main/java/com/zelusik/eatery/global/exception/kakao/KakaoTokenValidateException.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/kakao/KakaoTokenValidateException.java
@@ -1,0 +1,10 @@
+package com.zelusik.eatery.global.exception.kakao;
+
+import org.springframework.http.HttpStatus;
+
+public class KakaoTokenValidateException extends KakaoServerException {
+
+    public KakaoTokenValidateException(Integer errorCode, String errorMessage, Throwable cause) {
+        super(HttpStatus.UNAUTHORIZED, errorCode, errorMessage, cause);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zelusik/eatery/global/security/JwtAuthenticationFilter.java
@@ -48,11 +48,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (Exception ex) {
-                log.error(
-                        "[{}] JwtAuthenticationFilter.doFilterInternal() ex={}",
-                        LogUtils.getLogTraceId(),
-                        ExceptionUtils.getExceptionStackTrace(ex)
-                );
                 setErrorResponse(ex.getClass(), response);
             }
         }
@@ -73,7 +68,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         response.setCharacterEncoding("utf-8");
         response.setContentType("application/json; charset=UTF-8");
 
-        ExceptionType exceptionType = ExceptionType.from(classType);
+        ExceptionType exceptionType = ExceptionType.from(classType).orElse(ExceptionType.UNAUTHORIZED);
         ErrorResponse errorResponse = new ErrorResponse(exceptionType.getCode(), exceptionType.getMessage()
         );
         new ObjectMapper().writeValue(response.getOutputStream(), errorResponse);


### PR DESCRIPTION
## 🔥 Related Issue
- Close #7

## 🏃‍ Task
- kakao login 시 예외 처리 로직 세분화
  - kakao server에서 에러 응답 시 전달받은 code와 message를 활용하기 위해 `CustomException`과는 별개의, `KakaoServerException`이라는 class를 정의하였음.
  - 이에 따라 `ExceptionType` 로직을 일부 변경하였음. (기존 `from()` method가 `ExceptionType`을 바로 반환하는 것과는 다르게 `Optional<ExceptionType>`을 반환하여 특정 에러를 찾지 못했을 때 취해야 할 역할을 client에 위임.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
