### PR TITLE
Refresh token의 유효성을 확인하는 API 구현 / JWT 관련 예외 통합

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/controller/AuthController.java
+++ b/src/main/java/com/zelusik/eatery/app/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.zelusik.eatery.app.dto.auth.request.KakaoLoginRequest;
 import com.zelusik.eatery.app.dto.auth.request.TokenRefreshRequest;
 import com.zelusik.eatery.app.dto.auth.response.LoginResponse;
 import com.zelusik.eatery.app.dto.auth.response.TokenResponse;
+import com.zelusik.eatery.app.dto.auth.response.TokenValidateResponse;
 import com.zelusik.eatery.app.dto.member.MemberDto;
 import com.zelusik.eatery.app.dto.member.response.LoggedInMemberResponse;
 import com.zelusik.eatery.app.service.JwtTokenService;
@@ -20,15 +21,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 
 @Tag(name = "로그인 등 인증 관련")
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/api/auth")
 @RestController
 public class AuthController {
@@ -77,5 +78,20 @@ public class AuthController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(tokenResponse);
+    }
+
+    @Operation(
+            summary = "Refresh token 유효성 검사",
+            description = "<p>Refresh token의 유효성을 확인합니다.</p>" +
+                    "<p>유효하지 않은 refresh token이란 다음과 같은 경우를 말합니다.</p>" +
+                    "<ul>" +
+                    "<li>Refresh token의 값이 잘못된 경우</li>" +
+                    "<li>Refresh token이 만료된 경우</li>" +
+                    "<li>Refresh token의 발행 기록을 찾을 수 없는 경우</li>" +
+                    "</ul>"
+    )
+    @GetMapping("/validity")
+    public TokenValidateResponse validate(@RequestParam @NotBlank String refreshToken) {
+        return new TokenValidateResponse(jwtTokenService.validateOfRefreshToken(refreshToken));
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/controller/AuthController.java
+++ b/src/main/java/com/zelusik/eatery/app/controller/AuthController.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -68,10 +68,10 @@ public class AuthController {
     )
     @ApiResponses({
             @ApiResponse(description = "OK", responseCode = "200", content = @Content(schema = @Schema(implementation = TokenResponse.class))),
-            @ApiResponse(description = "[1507] 로그인 이력을 찾을 수 없는 경우. 즉, 서버가 전달받은 refresh token을 발행한 적이 없거나 refresh token이 만료된 경우.", responseCode = "404", content = @Content)
+            @ApiResponse(description = "[1502] 유효하지 않은 token으로 요청한 경우. Token 값이 잘못되었거나 만료되어 유효하지 않은 경우로 token 갱신 필요", responseCode = "401", content = @Content),
     })
     @PostMapping("/token")
-    public ResponseEntity<TokenResponse> refreshToken(@Valid @RequestBody TokenRefreshRequest request) {
+    public ResponseEntity<TokenResponse> tokenRefresh(@Valid @RequestBody TokenRefreshRequest request) {
         TokenResponse tokenResponse = jwtTokenService.refresh(request.getRefreshToken());
 
         return ResponseEntity

--- a/src/main/java/com/zelusik/eatery/app/dto/auth/response/TokenValidateResponse.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/auth/response/TokenValidateResponse.java
@@ -1,0 +1,13 @@
+package com.zelusik.eatery.app.dto.auth.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TokenValidateResponse {
+
+    @Schema(description = "유효성 여부. 유효한 토큰이라면 true", example = "true")
+    private Boolean isValid;
+}

--- a/src/main/java/com/zelusik/eatery/app/service/JwtTokenService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/JwtTokenService.java
@@ -63,4 +63,22 @@ public class JwtTokenService {
                 jwtTokenProvider.getLoginType(oldRefreshToken)
         );
     }
+
+    /**
+     * <p>
+     * Refresh token의 유효성을 검사한다.
+     * <p>
+     * Refresh token이 유효하지 않은 값인 경우, refresh token이 만료된 경우가 유효하지 않은 경우이다.
+     *
+     * @param refreshToken 유효성을 검사할 refreshToken
+     * @return refresh token의 유효성 검사 결과
+     */
+    public boolean validateOfRefreshToken(String refreshToken) {
+        try {
+            jwtTokenProvider.validateToken(refreshToken);
+        } catch (Exception ex) {
+            return false;
+        }
+        return redisRefreshTokenRepository.existsById(refreshToken);
+    }
 }

--- a/src/main/java/com/zelusik/eatery/app/service/JwtTokenService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/JwtTokenService.java
@@ -5,6 +5,7 @@ import com.zelusik.eatery.app.dto.auth.RedisRefreshToken;
 import com.zelusik.eatery.app.dto.auth.response.TokenResponse;
 import com.zelusik.eatery.app.repository.RedisRefreshTokenRepository;
 import com.zelusik.eatery.global.exception.auth.RedisRefreshTokenNotFoundException;
+import com.zelusik.eatery.global.exception.auth.TokenValidateException;
 import com.zelusik.eatery.global.security.JwtTokenInfoDto;
 import com.zelusik.eatery.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -47,13 +48,14 @@ public class JwtTokenService {
      *
      * @param oldRefreshToken 기존 발급받은 refresh token
      * @return 새롭게 생성된 access token과 refresh token 정보가 담긴 <code>TokenResponse</code> 객체
+     * @throws com.zelusik.eatery.global.exception.auth.TokenValidateException 유효하지 않은 token인 경우
      */
     @Transactional
     public TokenResponse refresh(String oldRefreshToken) {
         jwtTokenProvider.validateToken(oldRefreshToken);
 
         RedisRefreshToken oldRedisRefreshToken = redisRefreshTokenRepository.findById(oldRefreshToken)
-                .orElseThrow(RedisRefreshTokenNotFoundException::new);
+                .orElseThrow(TokenValidateException::new);
         redisRefreshTokenRepository.delete(oldRedisRefreshToken);
 
         return createJwtTokens(

--- a/src/main/java/com/zelusik/eatery/app/service/KakaoOAuthService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/KakaoOAuthService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zelusik.eatery.app.dto.auth.KakaoOAuthUserInfo;
 import com.zelusik.eatery.app.dto.exception.ErrorResponse;
 import com.zelusik.eatery.global.exception.kakao.KakaoServerException;
+import com.zelusik.eatery.global.exception.kakao.KakaoTokenValidateException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/zelusik/eatery/global/exception/ExceptionType.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/ExceptionType.java
@@ -102,12 +102,7 @@ public enum ExceptionType {
      */
     ACCESS_DENIED(1500, "접근이 거부되었습니다.", null),
     UNAUTHORIZED(1501, "유효하지 않은 인증 정보로 인해 인증 과정에서 문제가 발생하였습니다.", null),
-    JWT_UNSUPPORTED(1502, "처리할 수 없는 token입니다.", UnsupportedJwtException.class),
-    JWT_MALFORMED(1503, "유효하지 않은 token입니다.", MalformedJwtException.class),
-    JWT_INVALID_SIGNATURE(1504, "Token의 서명이 잘못되었습니다.", SignatureException.class),
-    JWT_EXPIRED(1505, "Token이 만료되었습니다. Token을 갱신하거나 다시 로그인 해주세요.", ExpiredJwtException.class),
-    TOKEN_VALIDATE(1506, "Token의 유효성을 검증하는 과정에서 문제가 발생했습니다. 관리자에게 문의해주세요.", TokenValidateException.class),
-    REDIS_REFRESH_TOKEN_NOT_FOUND(1507, "로그인 이력을 찾을 수 없습니다. 다시 로그인 해주세요.", RedisRefreshTokenNotFoundException.class),
+    TOKEN_VALIDATE(1502, "유효하지 않은 token입니다. Token 값이 잘못되었거나 만료되어 유효하지 않은 경우로 token 갱신이 필요합니다.", TokenValidateException.class),
 
     /**
      * 회원({@link Member}) 관련 예외

--- a/src/main/java/com/zelusik/eatery/global/exception/auth/TokenValidateException.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/auth/TokenValidateException.java
@@ -4,6 +4,10 @@ import com.zelusik.eatery.global.exception.common.InternalServerException;
 
 public class TokenValidateException extends InternalServerException {
 
+    public TokenValidateException() {
+        super();
+    }
+
     public TokenValidateException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/com/zelusik/eatery/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/zelusik/eatery/global/security/JwtTokenProvider.java
@@ -119,13 +119,6 @@ public class JwtTokenProvider {
                     .setSigningKey(secretKey)
                     .build()
                     .parseClaimsJws(token);
-        } catch (
-                UnsupportedJwtException |
-                MalformedJwtException |
-                SignatureException |
-                ExpiredJwtException ex
-        ) {
-            throw ex;
         } catch (Exception ex) {
             throw new TokenValidateException(ex);
         }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #22 

## 🏃‍ Task
- refresh token 유효성 검사 API 구현
- JWT 관련 에러 통합
  - Client 입장에서 jwt 관련 에러에 대해 세부적으로 알 필요는 없다고 생각하였음.
  - 예를 들어 서명이 잘못됐는지, 값이 잘못됐는지, 유효하지 않은지, 만료되었는지 세부적으로 알 필요는 없다고 생각했으며 결과적으로 유효하지 않은 token임을 알려주기만 하면 된다고 생각하였음.
  - Kakao developers rest api도 마찬가지로 token이 유효하지 않은 다양한 상황에서 하나의 에러 코드를 응답하는 것을 참고하여 수정하게 됨.
    - https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#get-token-info

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]    Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
