### PR TITLE
feat: #10 스토리 업로드 기능을 위해 내용 항목을 nullable로 설정.

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/dto/review/request/ReviewCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/review/request/ReviewCreateRequest.java
@@ -27,11 +27,9 @@ public class ReviewCreateRequest {
     private List<ReviewKeyword> keywords;
 
     @Schema(description = "자동으로 생성된 내용", example = "미래에 제가 살 곳은 여기로 정했습니다. 씹을 때마다...")
-    @Length(min = 1, max = 400)
     private String autoCreatedContent;
 
     @Schema(description = "업로드할 내용", example = "미래에 제가 살 곳은 여기로 정했습니다. 고기를 주문하면 ...")
-    @Length(min = 1, max = 400)
     private String content;
 
     @Schema(description = "업로드할 이미지 파일들")


### PR DESCRIPTION
## 🔥 Related Issue
- Close #10

## 🏃‍ Task
- 리뷰 작성 기능 중 스토리 업로드 기능이 가능하게끔 기존 코드 변경
  - `autoCreatedContent`, `content`를 nullable로 설정.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
