### PR TITLE
내 근처 가게 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // Jdbc Template
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/zelusik/eatery/app/controller/PlaceController.java
+++ b/src/main/java/com/zelusik/eatery/app/controller/PlaceController.java
@@ -1,19 +1,21 @@
 package com.zelusik.eatery.app.controller;
 
+import com.zelusik.eatery.app.dto.SliceResponse;
 import com.zelusik.eatery.app.dto.place.response.PlaceResponse;
 import com.zelusik.eatery.app.service.PlaceService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "가게 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/places")
 @RestController
@@ -33,5 +35,35 @@ public class PlaceController {
     @GetMapping("/{placeId}")
     public PlaceResponse find(@PathVariable Long placeId) {
         return PlaceResponse.from(placeService.findDtoById(placeId));
+    }
+
+    @Operation(
+            summary = "주변 가게 검색 (거리순 정렬)",
+            description = "<p>중심 좌표를 받아 중심 좌표에서 가까운 가게들을 검색합니다." +
+                    "<p>주변 3km 내에 있는 가게만 우선적으로 검색하며, 3km 이내에 아무런 가게가 없다면 10km로 검색 범위를 확대해 다시 검색합니다.",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @GetMapping("/search")
+    public SliceResponse<PlaceResponse> searchNearBy(
+            @Parameter(
+                    description = "중심 위치 - 위도",
+                    example = "37.566826004661"
+            ) @RequestParam String lat,
+            @Parameter(
+                    description = "중심 위치 - 경도",
+                    example = "126.978652258309"
+            ) @RequestParam String lng,
+            @Parameter(
+                    description = "페이지 번호(0부터 시작합니다). 기본값은 0입니다.",
+                    example = "0"
+            ) @RequestParam(required = false, defaultValue = "0") int page,
+            @Parameter(
+                    description = "한 페이지에 담긴 데이터의 최대 개수(사이즈). 기본값은 30입니다.",
+                    example = "30"
+            ) @RequestParam(required = false, defaultValue = "30") int size
+    ) {
+        return new SliceResponse<PlaceResponse>()
+                .from(placeService.findDtosNearBy(lat, lng, PageRequest.of(page, size))
+                        .map(PlaceResponse::from));
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/domain/BaseTimeEntity.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/BaseTimeEntity.java
@@ -1,6 +1,9 @@
 package com.zelusik.eatery.app.domain;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -10,6 +13,8 @@ import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass

--- a/src/main/java/com/zelusik/eatery/app/domain/place/Address.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/place/Address.java
@@ -2,6 +2,7 @@ package com.zelusik.eatery.app.domain.place;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
@@ -9,6 +10,7 @@ import org.springframework.util.StringUtils;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Embeddable

--- a/src/main/java/com/zelusik/eatery/app/domain/place/Place.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/place/Place.java
@@ -2,9 +2,7 @@ package com.zelusik.eatery.app.domain.place;
 
 import com.zelusik.eatery.app.domain.BaseTimeEntity;
 import com.zelusik.eatery.app.domain.constant.KakaoCategoryGroupCode;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
@@ -57,10 +55,32 @@ public class Place extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     public static Place of(String kakaoPid, String name, String pageUrl, KakaoCategoryGroupCode categoryGroupCode, PlaceCategory category, String phone, Address address, String homepageUrl, Point point, String closingHours) {
-        return new Place(kakaoPid, name, pageUrl, categoryGroupCode, category, phone, address, homepageUrl, point, closingHours);
+        return of(null, kakaoPid, name, pageUrl, categoryGroupCode, category, phone, address, homepageUrl, point, closingHours, null, null, null);
     }
 
-    private Place(String kakaoPid, String name, String pageUrl, KakaoCategoryGroupCode categoryGroupCode, PlaceCategory category, String phone, Address address, String homepageUrl, Point point, String closingHours) {
+    public static Place of(Long id, String kakaoPid, String name, String pageUrl, KakaoCategoryGroupCode categoryGroupCode, PlaceCategory category, String phone, Address address, String homepageUrl, Point point, String closingHours, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        return Place.builder()
+                .id(id)
+                .kakaoPid(kakaoPid)
+                .name(name)
+                .pageUrl(pageUrl)
+                .categoryGroupCode(categoryGroupCode)
+                .category(category)
+                .phone(phone)
+                .address(address)
+                .homepageUrl(homepageUrl)
+                .point(point)
+                .closingHours(closingHours)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .deletedAt(deletedAt)
+                .build();
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Place(LocalDateTime createdAt, LocalDateTime updatedAt, Long id, String kakaoPid, String name, String pageUrl, KakaoCategoryGroupCode categoryGroupCode, PlaceCategory category, String phone, Address address, String homepageUrl, Point point, String closingHours, LocalDateTime deletedAt) {
+        super(createdAt, updatedAt);
+        this.id = id;
         this.kakaoPid = kakaoPid;
         this.name = name;
         this.pageUrl = pageUrl;
@@ -71,5 +91,6 @@ public class Place extends BaseTimeEntity {
         this.homepageUrl = homepageUrl;
         this.point = point;
         this.closingHours = closingHours;
+        this.deletedAt = deletedAt;
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/domain/place/PlaceCategory.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/place/PlaceCategory.java
@@ -2,6 +2,7 @@ package com.zelusik.eatery.app.domain.place;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import java.util.Arrays;
 
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Embeddable

--- a/src/main/java/com/zelusik/eatery/app/dto/place/response/PlaceResponse.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/place/response/PlaceResponse.java
@@ -42,8 +42,11 @@ public class PlaceResponse {
     @Schema(description = "영업시간 정보")
     private List<OpeningHoursResponse> openingHours;
 
-    public static PlaceResponse of(Long id, String name, PlaceCategory category, String phone, Address address, String snsUrl, Point point, String closingHours, List<OpeningHoursResponse> openingHours) {
-        return new PlaceResponse(id, name, category, phone, address, snsUrl, point, closingHours, openingHours);
+    @Schema(description = "북마크 여부", example = "false")
+    private Boolean isMarked;
+
+    public static PlaceResponse of(Long id, String name, PlaceCategory category, String phone, Address address, String snsUrl, Point point, String closingHours, List<OpeningHoursResponse> openingHours, Boolean isMarked) {
+        return new PlaceResponse(id, name, category, phone, address, snsUrl, point, closingHours, openingHours, isMarked);
     }
 
     public static PlaceResponse from(PlaceDto placeDto) {
@@ -63,7 +66,8 @@ public class PlaceResponse {
                 placeDto.closingHours(),
                 placeDto.openingHoursDtos().stream()
                         .map(OpeningHoursResponse::from)
-                        .toList()
+                        .toList(),
+                false
         );
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/repository/PlaceJdbcTemplateRepository.java
+++ b/src/main/java/com/zelusik/eatery/app/repository/PlaceJdbcTemplateRepository.java
@@ -1,0 +1,18 @@
+package com.zelusik.eatery.app.repository;
+
+import com.zelusik.eatery.app.domain.place.Place;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface PlaceJdbcTemplateRepository {
+
+    /**
+     * 중심 좌표 기준, 가까운 순으로 장소 목록을 조회한다.
+     *
+     * @param lat      중심좌표의 위도
+     * @param lng      중심좌표의 경도
+     * @param pageable paging 정보
+     * @return 조회한 장소 목록
+     */
+    Slice<Place> findNearBy(String lat, String lng, int distanceLimit, Pageable pageable);
+}

--- a/src/main/java/com/zelusik/eatery/app/repository/PlaceJdbcTemplateRepositoryImpl.java
+++ b/src/main/java/com/zelusik/eatery/app/repository/PlaceJdbcTemplateRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.zelusik.eatery.app.repository;
+
+import com.zelusik.eatery.app.domain.constant.KakaoCategoryGroupCode;
+import com.zelusik.eatery.app.domain.place.Address;
+import com.zelusik.eatery.app.domain.place.Place;
+import com.zelusik.eatery.app.domain.place.PlaceCategory;
+import com.zelusik.eatery.app.domain.place.Point;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+public class PlaceJdbcTemplateRepositoryImpl implements PlaceJdbcTemplateRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    public PlaceJdbcTemplateRepositoryImpl(DataSource dataSource) {
+        this.template = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    @Override
+    public Slice<Place> findNearBy(String lat, String lng, int distanceLimit, Pageable pageable) {
+        String sql = "select place_id, kakao_pid, name, page_url, category_group_code, first_category, second_category, third_category, phone, sido, sgg, lot_number_address, road_address, homepage_url, lat, lng, closing_hours, created_at, updated_at, deleted_at, " +
+                "(6371 * acos(cos(radians(:lat)) * cos(radians(lat)) * cos(radians(lng) - radians(:lng)) + sin(radians(:lat)) * sin(radians(lat)))) as distance " +
+                "from place " +
+                "group by place_id, kakao_pid, name, page_url, category_group_code, first_category, second_category, third_category, phone, sido, sgg, lot_number_address, road_address, homepage_url, lat, lng, closing_hours, created_at, updated_at, deleted_at " +
+                "having distance <= :distance_limit " +
+                "order by distance " +
+                "limit :size " +
+                "offset :offset";
+
+        SqlParameterSource param = new MapSqlParameterSource()
+                .addValue("lat", lat)
+                .addValue("lng", lng)
+                .addValue("distance_limit", distanceLimit)
+                .addValue("size", pageable.getPageSize() + 1)   // 다음 페이지 존재 여부 확인을 위함.
+                .addValue("offset", pageable.getOffset());
+
+        List<Place> content = template.query(sql, param, placeRowMapper());
+
+        boolean hasNext = false;
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    private RowMapper<Place> placeRowMapper() {
+        return (rs, rowNum) -> Place.of(
+                rs.getLong("place_id"),
+                rs.getString("kakao_pid"),
+                rs.getString("name"),
+                rs.getString("page_url"),
+                KakaoCategoryGroupCode.valueOf(rs.getString("category_group_code")),
+                new PlaceCategory(
+                        rs.getString("first_category"),
+                        rs.getString("second_category"),
+                        rs.getString("third_category")
+                ),
+                rs.getString("phone"),
+                new Address(
+                        rs.getString("sido"),
+                        rs.getString("sgg"),
+                        rs.getString("lot_number_address"),
+                        rs.getString("road_address")
+                ),
+                rs.getString("homepage_url"),
+                new Point(
+                        rs.getString("lat"),
+                        rs.getString("lng")
+                ),
+                rs.getString("closing_hours"),
+                rs.getTimestamp("created_at").toLocalDateTime(),
+                rs.getTimestamp("updated_at").toLocalDateTime(),
+                rs.getTimestamp("deleted_at") == null ? null : rs.getTimestamp("deleted_at").toLocalDateTime()
+        );
+    }
+}

--- a/src/main/java/com/zelusik/eatery/app/repository/PlaceRepository.java
+++ b/src/main/java/com/zelusik/eatery/app/repository/PlaceRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface PlaceRepository extends JpaRepository<Place, Long> {
+public interface PlaceRepository extends
+        JpaRepository<Place, Long>,
+        PlaceJdbcTemplateRepository {
 
     Optional<Place> findByKakaoPid(String kakaoPid);
 }

--- a/src/main/java/com/zelusik/eatery/app/service/PlaceService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/PlaceService.java
@@ -11,6 +11,8 @@ import com.zelusik.eatery.app.repository.PlaceRepository;
 import com.zelusik.eatery.global.exception.place.PlaceNotFoundException;
 import com.zelusik.eatery.global.exception.scraping.OpeningHoursUnexpectedFormatException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,6 +66,22 @@ public class PlaceService {
      */
     public Optional<Place> findOptEntityByKakaoPid(String kakaoPid) {
         return placeRepository.findByKakaoPid(kakaoPid);
+    }
+
+    /**
+     * 중심 좌표 기준, 가까운 순으로 장소 목록을 조회한다.
+     *
+     * @param lat      중심좌표의 위도
+     * @param lng      중심좌표의 경도
+     * @param pageable paging 정보
+     * @return 조회한 장소 목록
+     */
+    public Slice<PlaceDto> findDtosNearBy(String lat, String lng, Pageable pageable) {
+        Slice<Place> places = placeRepository.findNearBy(lat, lng, 3, pageable);
+        if (!places.hasContent()) {
+            places = placeRepository.findNearBy(lat, lng, 10, pageable);
+        }
+        return places.map(PlaceDto::from);
     }
 
     /**

--- a/src/test/java/com/zelusik/eatery/app/repository/place/PlaceRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/app/repository/place/PlaceRepositoryTest.java
@@ -1,0 +1,87 @@
+package com.zelusik.eatery.app.repository.place;
+
+import com.zelusik.eatery.app.domain.place.Place;
+import com.zelusik.eatery.app.domain.place.Point;
+import com.zelusik.eatery.app.repository.PlaceRepository;
+import com.zelusik.eatery.util.PlaceTestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 대한민국 북-남 거리 약 1,100km
+ */
+
+@DisplayName("[Repository] Place")
+@ActiveProfiles("test")
+@DataJpaTest
+class PlaceRepositoryTest {
+
+    private final PlaceRepository placeRepository;
+
+    public PlaceRepositoryTest(@Autowired PlaceRepository placeRepository) {
+        this.placeRepository = placeRepository;
+    }
+
+    @DisplayName("장소들이 존재하고, 중심 좌표 주변의 장소를 조회하면, 거리순으로 정렬된 장소 목록이 반환된다.")
+    @Test
+    void givenPlaces_whenFindNearBy_thenReturnPlaceSliceSortedByDistance() {
+        // given
+        String centerLat = "37";
+        String centerLng = "127";
+        for (int i = 0; i < 50; i++) {
+            placeRepository.save(PlaceTestUtils.createPlace(
+                    (long) (i + 1),
+                    null,
+                    centerLat,
+                    String.valueOf(Integer.parseInt(centerLng) + Math.random()),
+                    null
+            ));
+        }
+
+        // when
+        Slice<Place> places = placeRepository.findNearBy(centerLat, centerLng, 1100, PageRequest.of(0, 30));
+
+        // then
+        assertThat(places.getSize()).isEqualTo(30);
+        assertThat(places.hasNext()).isTrue();
+        for (int i = 0; i < places.getSize() - 1; i++) {
+            Place curPlace = places.getContent().get(i);
+            Place nextPlace = places.getContent().get(i + 1);
+            assertThat(calculateDiff(centerLng, curPlace.getPoint().getLng()))
+                    .isLessThanOrEqualTo(calculateDiff(centerLng, nextPlace.getPoint().getLng()));
+        }
+    }
+
+    @DisplayName("주변 장소를 조회하면, 50km와 1100km 내에 있는 가게들을 조회한다.")
+    @Test
+    void givenPlaces_whenFindNearBy_thenReturnPlacesWith50kmAnd1100km() {
+        // given
+        Point pos = new Point("37.5776087830657", "126.976896737645");  // 경복궁
+        placeRepository.save(PlaceTestUtils.createPlace(1L, "성심당", "36.32765802936324", "127.42727719121109", null));   // 대전
+        placeRepository.save(PlaceTestUtils.createPlace(2L, "해운대암소갈비집", "35.163310169485634", "129.1666092786243", null));  // 부산
+        placeRepository.save(PlaceTestUtils.createPlace(3L, "연남토마 본점", "37.5595073462493", "126.921462488105", null));   // 서울
+        placeRepository.save(PlaceTestUtils.createPlace(4L, "연돈", "33.258895288625645", "126.40715814631936", null));   // 제주
+        placeRepository.save(PlaceTestUtils.createPlace(5L, "본수원갈비", "37.27796181430103", "127.04060364807957", null));   // 수원
+
+        // when
+        Pageable pageable = Pageable.ofSize(30);
+        Slice<Place> placesLimit50 = placeRepository.findNearBy(pos.getLat(), pos.getLng(), 50, pageable);
+        Slice<Place> placesLimit1100 = placeRepository.findNearBy(pos.getLat(), pos.getLng(), 1100, pageable);
+
+        // then
+        assertThat(placesLimit50.getNumberOfElements()).isEqualTo(2);
+        assertThat(placesLimit1100.getNumberOfElements()).isEqualTo(5);
+    }
+
+    private double calculateDiff(String centerLng, String placeLng) {
+        return Math.abs(Double.parseDouble(centerLng) - Double.parseDouble(placeLng));
+    }
+}

--- a/src/test/java/com/zelusik/eatery/app/service/PlaceServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/app/service/PlaceServiceTest.java
@@ -60,7 +60,7 @@ class PlaceServiceTest {
         // given
         PlaceRequest placeRequest = PlaceTestUtils.createPlaceRequest();
         String homepageUrl = "www.instagram.com/toma_wv";
-        Place expectedSavedPlace = PlaceTestUtils.createPlaceWithId(homepageUrl, closingHours);
+        Place expectedSavedPlace = PlaceTestUtils.createPlace(1L, homepageUrl, closingHours);
         given(placeRepository.save(any(Place.class))).willReturn(expectedSavedPlace);
         given(openingHoursRepository.saveAll(any())).willReturn(any());
 
@@ -90,7 +90,7 @@ class PlaceServiceTest {
         // given
         PlaceRequest placeRequest = PlaceTestUtils.createPlaceRequest();
         String homepageUrl = "www.instagram.com/toma_wv";
-        Place expectedSavedPlace = PlaceTestUtils.createPlaceWithId(homepageUrl, closingHours);
+        Place expectedSavedPlace = PlaceTestUtils.createPlace(1L, homepageUrl, closingHours);
         given(placeRepository.save(any(Place.class))).willReturn(expectedSavedPlace);
         given(openingHoursRepository.saveAll(any())).willReturn(any());
 
@@ -122,7 +122,7 @@ class PlaceServiceTest {
         // given
         PlaceRequest placeRequest = PlaceTestUtils.createPlaceRequest();
         String homepageUrl = "www.instagram.com/toma_wv";
-        Place expectedSavedPlace = PlaceTestUtils.createPlaceWithId(homepageUrl, closingHours);
+        Place expectedSavedPlace = PlaceTestUtils.createPlace(1L, homepageUrl, closingHours);
         given(placeRepository.save(any(Place.class))).willReturn(expectedSavedPlace);
         given(openingHoursRepository.saveAll(any())).willReturn(any());
 
@@ -158,7 +158,7 @@ class PlaceServiceTest {
                 SAT, new OpeningHoursTimeDto(LocalTime.of(11, 0), LocalTime.of(19, 0)),
                 SUN, new OpeningHoursTimeDto(LocalTime.of(11, 0), LocalTime.of(19, 0))
         );
-        Place expectedSavedPlace = PlaceTestUtils.createPlaceWithId(homepageUrl, closingHours);
+        Place expectedSavedPlace = PlaceTestUtils.createPlace(1L, homepageUrl, closingHours);
         given(placeRepository.save(any(Place.class))).willReturn(expectedSavedPlace);
         given(openingHoursRepository.save(any(OpeningHours.class)))
                 .willReturn(OpeningHours.of(
@@ -208,7 +208,7 @@ class PlaceServiceTest {
     void givenId_whenFindExistentPlace_thenReturnPlaceDto() {
         // given
         long placeId = 1L;
-        given(placeRepository.findById(placeId)).willReturn(Optional.of(PlaceTestUtils.createPlaceWithId()));
+        given(placeRepository.findById(placeId)).willReturn(Optional.of(PlaceTestUtils.createPlace()));
         
         // when
         PlaceDto findDto = sut.findDtoById(placeId);
@@ -238,7 +238,7 @@ class PlaceServiceTest {
     void givenKakaoPid_whenFindExistentPlace_thenReturnOptionalPlace() {
         // given
         String kakaoPid = "test";
-        Place expectedPlace = PlaceTestUtils.createPlaceWithId();
+        Place expectedPlace = PlaceTestUtils.createPlace();
         given(placeRepository.findByKakaoPid(kakaoPid)).willReturn(Optional.of(expectedPlace));
 
         // when

--- a/src/test/java/com/zelusik/eatery/app/service/ReviewServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/app/service/ReviewServiceTest.java
@@ -53,7 +53,7 @@ class ReviewServiceTest {
         ReviewCreateRequest reviewCreateRequest = ReviewTestUtils.createReviewCreateRequest();
         String kakaoPid = reviewCreateRequest.getPlace().getKakaoPid();
         long writerId = 1L;
-        Place expectedPlace = PlaceTestUtils.createPlaceWithId();
+        Place expectedPlace = PlaceTestUtils.createPlace();
         Member expectedMember = MemberTestUtils.createMemberWithId();
         given(placeService.findOptEntityByKakaoPid(kakaoPid)).willReturn(Optional.of(expectedPlace));
         given(memberService.findEntityById(writerId)).willReturn(expectedMember);
@@ -85,7 +85,7 @@ class ReviewServiceTest {
         String homepageUrl = "homepage";
         String openingHours = "매일 00:00 ~ 24:00";
         String closingHours = null;
-        Place expectedPlace = PlaceTestUtils.createPlaceWithId();
+        Place expectedPlace = PlaceTestUtils.createPlace();
         Member expectedMember = MemberTestUtils.createMemberWithId();
         given(placeService.findOptEntityByKakaoPid(kakaoPid))
                 .willReturn(Optional.empty());

--- a/src/test/java/com/zelusik/eatery/util/PlaceTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/PlaceTestUtils.java
@@ -11,6 +11,7 @@ import com.zelusik.eatery.app.dto.place.PlaceDto;
 import com.zelusik.eatery.app.dto.place.request.PlaceRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -55,20 +56,35 @@ public class PlaceTestUtils {
         );
     }
 
-    public static Place createPlace(String homepageUrl, String closingHours) {
-        return createPlaceRequest()
-                .toDto(homepageUrl, closingHours)
-                .toEntity();
+    public static Place createPlace() {
+        return createPlace(1L);
     }
 
-    public static Place createPlaceWithId() {
-        return createPlaceWithId(null, null);
+    public static Place createPlace(Long id) {
+        return createPlace(id, null, "37.5595073462493", "126.921462488105", null);
     }
 
-    public static Place createPlaceWithId(String homepageUrl, String closingHours) {
-        Place place = createPlace(homepageUrl, closingHours);
-        ReflectionTestUtils.setField(place, "id", 1L);
-        return place;
+    public static Place createPlace(Long id, String homepageUrl, String closingHours) {
+        return createPlace(id, homepageUrl, "37.5595073462493", "126.921462488105", closingHours);
+    }
+
+    public static Place createPlace(Long id, String homepageUrl, String lat, String lng, String closingHours) {
+        return Place.of(
+                id,
+                "308342289",
+                "연남토마 본점",
+                "http://place.map.kakao.com/308342289",
+                KakaoCategoryGroupCode.FD6,
+                new PlaceCategory("음식점 > 퓨전요리 > 퓨전일식"),
+                "02-332-8064",
+                new Address("서울 마포구 연남동 568-26", "서울 마포구 월드컵북로6길 61"),
+                homepageUrl,
+                new Point(lat, lng),
+                closingHours,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null
+        );
     }
 
     private static OpeningHoursDto createOpeningHoursDto(

--- a/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
@@ -51,7 +51,7 @@ public class ReviewTestUtils {
     public static Review createReviewWithId() {
         return createReviewWithId(
                 MemberTestUtils.createMemberWithId(),
-                PlaceTestUtils.createPlaceWithId()
+                PlaceTestUtils.createPlace()
         );
     }
 


### PR DESCRIPTION
## 🔥 Related Issue
- Close #29 

## 🏃‍ Task
- 특정 좌표 근처에 있는 가게들을 조회하는 API를 구현한다.
  - 우선적으로 주변 3km 내에 있는 가게들을 거리순으로 정렬해 조회하며, 만약 조회 결과가 없다면 범위를 10km로 확장하여 조회한다.

## 📄 Reference
- None

## ✅ Check List
- [x] PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
