### PR TITLE
가게 검색 API에서 약속 상황(keyword)를 한글로 요청했을 때 처리하지 못하는 버그 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/util/controller/PlaceSearchKeywordConverter.java
+++ b/src/main/java/com/zelusik/eatery/app/util/controller/PlaceSearchKeywordConverter.java
@@ -7,6 +7,6 @@ public class PlaceSearchKeywordConverter implements Converter<String, PlaceSearc
 
     @Override
     public PlaceSearchKeyword convert(String source) {
-        return PlaceSearchKeyword.valueOf(source);
+        return PlaceSearchKeyword.valueOfDescription(source);
     }
 }

--- a/src/test/java/com/zelusik/eatery/app/controller/PlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/app/controller/PlaceControllerTest.java
@@ -2,6 +2,7 @@ package com.zelusik.eatery.app.controller;
 
 import com.zelusik.eatery.app.config.SecurityConfig;
 import com.zelusik.eatery.app.constant.place.DayOfWeek;
+import com.zelusik.eatery.app.constant.place.PlaceSearchKeyword;
 import com.zelusik.eatery.app.dto.place.PlaceDto;
 import com.zelusik.eatery.app.dto.place.response.PlaceResponse;
 import com.zelusik.eatery.app.service.PlaceService;
@@ -77,11 +78,11 @@ class PlaceControllerTest {
         String lng = "127";
         Pageable pageable = Pageable.ofSize(30);
         SliceImpl<PlaceDto> expectedResult = new SliceImpl<>(List.of(PlaceTestUtils.createPlaceDtoWithIdAndOpeningHours()), pageable, false);
-        given(placeService.findDtosNearBy(List.of(MON, WED, FRI), null, lat, lng, pageable)).willReturn(expectedResult);
+        given(placeService.findDtosNearBy(List.of(MON, WED, FRI), PlaceSearchKeyword.ALONE, lat, lng, pageable)).willReturn(expectedResult);
 
         // when & then
         mvc.perform(
-                        get("/api/places/search?lat=" + lat + "&lng=" + lng + "&daysOfWeek=월,수,금")
+                        get("/api/places/search?lat=" + lat + "&lng=" + lng + "&daysOfWeek=월,수,금" + "&keyword=혼밥")
                                 .with(csrf())
                                 .with(user(UserPrincipal.of(MemberTestUtils.createMemberDtoWithId())))
                 )


### PR DESCRIPTION
## 🔥 Related Issue
- Close #32 

## 🏃‍ Task
- `PlaceSearchKeywordConverter`에서 `String` type의 값을 converting 할 때 `valueOf()`가 아닌 `valueOfDescription()`을 사용하도록 하여 정상적으로 문자열이 `PlaceSearchKeyword` type으로 변환되도록 수정하였음.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
