### PR TITLE
jwt error response 로직 변경

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/config/SecurityConfig.java
+++ b/src/main/java/com/zelusik/eatery/app/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.app.config;
 import com.zelusik.eatery.global.security.JwtAccessDeniedHandler;
 import com.zelusik.eatery.global.security.JwtAuthenticationEntryPoint;
 import com.zelusik.eatery.global.security.JwtAuthenticationFilter;
+import com.zelusik.eatery.global.security.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
@@ -21,6 +22,7 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
@@ -49,6 +51,7 @@ public class SecurityConfig {
                         }
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, jwtAuthenticationFilter.getClass())
                 .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/java/com/zelusik/eatery/global/security/JwtExceptionFilter.java
+++ b/src/main/java/com/zelusik/eatery/global/security/JwtExceptionFilter.java
@@ -1,0 +1,46 @@
+package com.zelusik.eatery.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zelusik.eatery.app.dto.exception.ErrorResponse;
+import com.zelusik.eatery.global.exception.ExceptionType;
+import com.zelusik.eatery.global.exception.auth.TokenValidateException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (TokenValidateException ex) {
+            setErrorResponse(ex.getClass(), response);
+        }
+    }
+
+    /**
+     * Exception 정보를 입력받아 응답할 error response를 설정한다.
+     *
+     * @param classType Exception의 class type
+     * @param response  HttpServletResponse 객체
+     */
+    private void setErrorResponse(
+            Class<? extends Exception> classType,
+            HttpServletResponse response
+    ) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding("utf-8");
+        response.setContentType("application/json; charset=UTF-8");
+
+        ExceptionType exceptionType = ExceptionType.from(classType).orElse(ExceptionType.UNAUTHORIZED);
+        ErrorResponse errorResponse = new ErrorResponse(exceptionType.getCode(), exceptionType.getMessage());
+        new ObjectMapper().writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/zelusik/eatery/global/security/JwtTokenProvider.java
@@ -3,7 +3,9 @@ package com.zelusik.eatery.global.security;
 import com.zelusik.eatery.app.constant.member.LoginType;
 import com.zelusik.eatery.app.constant.member.RoleType;
 import com.zelusik.eatery.global.exception.auth.TokenValidateException;
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +35,7 @@ public class JwtTokenProvider {
     private static final long MINUTE = 1000 * 60L;
     private static final long HOUR = 60 * MINUTE;
     private static final long DAY = 24 * HOUR;
-    private static final long ACCESS_TOKEN_EXPIRED_DURATION = 12 * HOUR; // Access token 만료시간 : 12시간
+    private static final long ACCESS_TOKEN_EXPIRED_DURATION = DAY; // Access token 만료시간 : 한 달 (개발용)
     public static final long REFRESH_TOKEN_EXPIRED_DURATION = 30 * DAY; // Refresh token 만료시간 : 한 달
 
     private static final String TOKEN_TYPE_BEARER = "Bearer ";


### PR DESCRIPTION
## 🔥 Related Issue
- Close #23

## 🏃‍ Task
- 기존에 jwt 관련 예외가 발생할 경우 해당 예외를 catch 하기 때문에 `doFilter()`가 그대로 동작하여 에러 응답이 두개가 작성되었다.
- 이에, exception은 그냥 던지도록 하여 `doFilter()`가 동작되지 않도록 하였고, 여기서 던져진 exception을 따로 받아서 응답하는 filter를 하나 추가했다.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
