### PR TITLE
장소 검색, 조회 시 "요일" 정보와 "약속 상황"을 보내지 않을 경우 에러가 발생하는 버그 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/controller/PlaceController.java
+++ b/src/main/java/com/zelusik/eatery/app/controller/PlaceController.java
@@ -102,12 +102,9 @@ public class PlaceController {
     ) {
         return new SliceResponse<PlaceResponse>()
                 .from(placeService.findDtosNearBy(
-                        daysOfWeek.stream()
-                                .map(DayOfWeek::valueOfDescription)
-                                .toList(),
-                        PlaceSearchKeyword.valueOfDescription(keyword),
-                        lat,
-                        lng,
+                        daysOfWeek == null ? null : daysOfWeek.stream().map(DayOfWeek::valueOfDescription).toList(),
+                        keyword == null ? null : PlaceSearchKeyword.valueOfDescription(keyword),
+                        lat, lng,
                         PageRequest.of(page, size)
                 ).map(PlaceResponse::from));
     }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #57

## 🏃‍ Task
- 장소 검색, 조회 시 "요일" 정보와 "약속 상황"을 보내지 않을 경우 에러가 발생하는 버그 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
