### PR TITLE
필수 이용 약관에 동의하지 않았을 경우 에러가 발생하도록 변경, 미성년자 동의 항목 필드명 변경

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/controller/MemberController.java
+++ b/src/main/java/com/zelusik/eatery/app/controller/MemberController.java
@@ -9,6 +9,10 @@ import com.zelusik.eatery.app.service.MemberService;
 import com.zelusik.eatery.global.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -33,10 +37,14 @@ public class MemberController {
             description = "<p>전체 약관에 대한 동의/비동의 결과를 제출한다.",
             security = @SecurityRequirement(name = "access-token")
     )
+    @ApiResponses({
+            @ApiResponse(description = "OK", responseCode = "201", content = @Content(schema = @Schema(implementation = TermsInfoResponse.class))),
+            @ApiResponse(description = "[1200] 필수 이용 약관이 `false`로 전달된 경우", responseCode = "422", content = @Content)
+    })
     @PostMapping("/terms")
     public ResponseEntity<TermsInfoResponse> agree(
             @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @RequestBody TermsAgreeRequest request
+            @Valid @RequestBody TermsAgreeRequest request
     ) {
         TermsInfoResponse response = TermsInfoResponse.from(memberService.agreeToTerms(userPrincipal.getMemberId(), request));
 

--- a/src/main/java/com/zelusik/eatery/app/domain/TermsInfo.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/TermsInfo.java
@@ -19,7 +19,7 @@ public class TermsInfo extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
-    private Boolean isMinor;
+    private Boolean isNotMinor;
 
     @Column(nullable = false)
     private Boolean service;
@@ -41,14 +41,14 @@ public class TermsInfo extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDateTime marketingReceptionUpdatedAt;
 
-    public static TermsInfo of(Boolean isMinor, Boolean service, LocalDateTime serviceUpdatedAt, Boolean userInfo, LocalDateTime userInfoUpdatedAt, Boolean locationInfo, LocalDateTime locationInfoUpdatedAt, Boolean marketingReception, LocalDateTime marketingReceptionUpdatedAt) {
-        return of(null, isMinor, service, serviceUpdatedAt, userInfo, userInfoUpdatedAt, locationInfo, locationInfoUpdatedAt, marketingReception, marketingReceptionUpdatedAt, null, null);
+    public static TermsInfo of(Boolean isNotMinor, Boolean service, LocalDateTime serviceUpdatedAt, Boolean userInfo, LocalDateTime userInfoUpdatedAt, Boolean locationInfo, LocalDateTime locationInfoUpdatedAt, Boolean marketingReception, LocalDateTime marketingReceptionUpdatedAt) {
+        return of(null, isNotMinor, service, serviceUpdatedAt, userInfo, userInfoUpdatedAt, locationInfo, locationInfoUpdatedAt, marketingReception, marketingReceptionUpdatedAt, null, null);
     }
 
-    public static TermsInfo of(Long id, Boolean isMinor, Boolean service, LocalDateTime serviceUpdatedAt, Boolean userInfo, LocalDateTime userInfoUpdatedAt, Boolean locationInfo, LocalDateTime locationInfoUpdatedAt, Boolean marketingReception, LocalDateTime marketingReceptionUpdatedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public static TermsInfo of(Long id, Boolean isNotMinor, Boolean service, LocalDateTime serviceUpdatedAt, Boolean userInfo, LocalDateTime userInfoUpdatedAt, Boolean locationInfo, LocalDateTime locationInfoUpdatedAt, Boolean marketingReception, LocalDateTime marketingReceptionUpdatedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
         return TermsInfo.builder()
                 .id(id)
-                .isMinor(isMinor)
+                .isNotMinor(isNotMinor)
                 .service(service)
                 .serviceUpdatedAt(serviceUpdatedAt)
                 .userInfo(userInfo)
@@ -63,10 +63,10 @@ public class TermsInfo extends BaseTimeEntity {
     }
 
     @Builder(access = AccessLevel.PRIVATE)
-    private TermsInfo(LocalDateTime createdAt, LocalDateTime updatedAt, Long id, Boolean isMinor, Boolean service, LocalDateTime serviceUpdatedAt, Boolean userInfo, LocalDateTime userInfoUpdatedAt, Boolean locationInfo, LocalDateTime locationInfoUpdatedAt, Boolean marketingReception, LocalDateTime marketingReceptionUpdatedAt) {
+    private TermsInfo(LocalDateTime createdAt, LocalDateTime updatedAt, Long id, Boolean isNotMinor, Boolean service, LocalDateTime serviceUpdatedAt, Boolean userInfo, LocalDateTime userInfoUpdatedAt, Boolean locationInfo, LocalDateTime locationInfoUpdatedAt, Boolean marketingReception, LocalDateTime marketingReceptionUpdatedAt) {
         super(createdAt, updatedAt);
         this.id = id;
-        this.isMinor = isMinor;
+        this.isNotMinor = isNotMinor;
         this.service = service;
         this.serviceUpdatedAt = serviceUpdatedAt;
         this.userInfo = userInfo;

--- a/src/main/java/com/zelusik/eatery/app/dto/member/request/TermsAgreeRequest.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/member/request/TermsAgreeRequest.java
@@ -6,18 +6,23 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.AssertTrue;
+
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class TermsAgreeRequest {
 
-    @Schema(description = "미성년자 여부. 만 14세 이상이라면 false", example = "false")
-    private Boolean isMinor;
+    @Schema(description = "미성년자 여부. 만 14세 이상이라면 true", example = "true")
+    @AssertTrue
+    private Boolean isNotMinor;
 
     @Schema(description = "서비스 이용약관 동의", example = "true")
+    @AssertTrue
     private Boolean service;
 
     @Schema(description = "개인정보 수집/이용 동의", example = "true")
+    @AssertTrue
     private Boolean userInfo;
 
     @Schema(description = "위치 정보 제공 동의", example = "true")
@@ -26,7 +31,7 @@ public class TermsAgreeRequest {
     @Schema(description = "마케팅 수신 동의", example = "false")
     private Boolean marketingReception;
 
-    public static TermsAgreeRequest of(Boolean isMinor, Boolean service, Boolean userInfo, Boolean locationInfo, Boolean marketingReception) {
-        return new TermsAgreeRequest(isMinor, service, userInfo, locationInfo, marketingReception);
+    public static TermsAgreeRequest of(Boolean isNotMinor, Boolean service, Boolean userInfo, Boolean locationInfo, Boolean marketingReception) {
+        return new TermsAgreeRequest(isNotMinor, service, userInfo, locationInfo, marketingReception);
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/dto/terms_info/TermsInfoDto.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/terms_info/TermsInfoDto.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 
 public record TermsInfoDto(
         Long id,
-        Boolean isMinor,
+        Boolean isNotMinor,
         Boolean service,
         LocalDateTime serviceUpdatedAt,
         Boolean userInfo,
@@ -19,8 +19,8 @@ public record TermsInfoDto(
         LocalDateTime updatedAt
 ) {
 
-    public static TermsInfoDto of(Long id, Boolean isMinor, Boolean service, LocalDateTime serviceUpdatedAt, Boolean userInfo, LocalDateTime userInfoUpdatedAt, Boolean locationInfo, LocalDateTime locationInfoUpdatedAt, Boolean marketingReception, LocalDateTime marketingReceptionUpdatedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        return new TermsInfoDto(id, isMinor, service, serviceUpdatedAt, userInfo, userInfoUpdatedAt, locationInfo, locationInfoUpdatedAt, marketingReception, marketingReceptionUpdatedAt, createdAt, updatedAt);
+    public static TermsInfoDto of(Long id, Boolean isNotMinor, Boolean service, LocalDateTime serviceUpdatedAt, Boolean userInfo, LocalDateTime userInfoUpdatedAt, Boolean locationInfo, LocalDateTime locationInfoUpdatedAt, Boolean marketingReception, LocalDateTime marketingReceptionUpdatedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new TermsInfoDto(id, isNotMinor, service, serviceUpdatedAt, userInfo, userInfoUpdatedAt, locationInfo, locationInfoUpdatedAt, marketingReception, marketingReceptionUpdatedAt, createdAt, updatedAt);
     }
 
     public static TermsInfoDto from(TermsInfo entity) {
@@ -30,7 +30,7 @@ public record TermsInfoDto(
 
         return of(
                 entity.getId(),
-                entity.getIsMinor(),
+                entity.getIsNotMinor(),
                 entity.getService(),
                 entity.getServiceUpdatedAt(),
                 entity.getUserInfo(),

--- a/src/main/java/com/zelusik/eatery/app/dto/terms_info/response/TermsInfoResponse.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/terms_info/response/TermsInfoResponse.java
@@ -15,8 +15,8 @@ public class TermsInfoResponse {
     @Schema(description = "약관 동의 entity의 PK", example = "1")
     private Long id;
 
-    @Schema(description = "미성년자(14세 미만) 여부", example = "false")
-    private Boolean isMinor;
+    @Schema(description = "미성년자(14세 미만) 여부", example = "true")
+    private Boolean isNotMinor;
 
     @Schema(description = "서비스 약관 동의 여부", example = "true")
     private Boolean service;
@@ -49,7 +49,7 @@ public class TermsInfoResponse {
 
         return new TermsInfoResponse(
                 termsInfoDto.id(),
-                termsInfoDto.isMinor(),
+                termsInfoDto.isNotMinor(),
                 termsInfoDto.service(), termsInfoDto.serviceUpdatedAt(),
                 termsInfoDto.userInfo(), termsInfoDto.userInfoUpdatedAt(),
                 termsInfoDto.locationInfo(), termsInfoDto.locationInfoUpdatedAt(),

--- a/src/main/java/com/zelusik/eatery/app/service/MemberService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/MemberService.java
@@ -47,7 +47,7 @@ public class MemberService {
     public TermsInfoDto agreeToTerms(Long memberId, TermsAgreeRequest request) {
         LocalDateTime now = LocalDateTime.now();
         TermsInfo termsInfo = TermsInfo.of(
-                request.getIsMinor(),
+                request.getIsNotMinor(),
                 request.getService(), now,
                 request.getUserInfo(), now,
                 request.getLocationInfo(), now,

--- a/src/main/java/com/zelusik/eatery/global/exception/ExceptionType.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/ExceptionType.java
@@ -72,7 +72,7 @@ public enum ExceptionType {
      * @see ValidationErrorCode
      */
     METHOD_ARGUMENT_NOT_VALID(1200, "요청 데이터가 잘못되었습니다.", MethodArgumentNotValidException.class),
-    CONSTRAINT_VIOLATION(1201, "요청 데이터가 잘못되었습니다.", ConstraintViolationException.class),
+    CONSTRAINT_VIOLATION(1200, "요청 데이터가 잘못되었습니다.", ConstraintViolationException.class),
 
     /**
      * Spring MVC Default Exception

--- a/src/test/java/com/zelusik/eatery/app/service/MemberServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/app/service/MemberServiceTest.java
@@ -67,7 +67,7 @@ class MemberServiceTest {
     void givenAgreeOfTermsInfo_whenAgreeToTerms_thenReturnTermsInfoResult() {
         // given
         long memberId = 1L;
-        TermsAgreeRequest termsAgreeRequest = TermsAgreeRequest.of(false, true, true, true, true);
+        TermsAgreeRequest termsAgreeRequest = TermsAgreeRequest.of(true, true, true, true, true);
         given(termsInfoRepository.save(any(TermsInfo.class))).willReturn(createTermsInfo());
         given(memberRepository.findById(memberId)).willReturn(Optional.of(createMember(memberId)));
 
@@ -77,7 +77,7 @@ class MemberServiceTest {
         // then
         then(termsInfoRepository).should().save(any(TermsInfo.class));
         then(memberRepository).should().findById(memberId);
-        assertThat(actualResult.isMinor()).isFalse();
+        assertThat(actualResult.isNotMinor()).isTrue();
     }
 
     @DisplayName("회원의 id(PK)가 주어지면 해당하는 회원을 조회한 후 반환한다.")


### PR DESCRIPTION
## 🔥 Related Issue
- Close #59

## 🏃‍ Task
- 필수 이용 약관에 동의하지 않았을 경우 에러가 발생하도록 변경
- 미성년자 동의 항목 필드명 변경. `isMinor` => `isNotMinor`

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]   Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
