### PR TITLE
Enum class의 한글<=>영어 변환 로직(valueOfDescription)이 공백에 상관없이 동작하도록 구현

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/constant/FoodCategory.java
+++ b/src/main/java/com/zelusik/eatery/app/constant/FoodCategory.java
@@ -44,9 +44,12 @@ public enum FoodCategory {
     private final String description;
 
     public static FoodCategory valueOfDescription(String description) {
+        String trimmedDescription = description.replace(" ", "");
+
         return Arrays.stream(values())
-                .filter(value -> description.equals(value.getDescription()))
-                .findFirst()
+                .filter(value -> trimmedDescription.equals(
+                        value.getDescription().replace(" ", "")
+                )).findFirst()
                 .orElseThrow(NotAcceptableFoodCategory::new);
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/constant/place/PlaceSearchKeyword.java
+++ b/src/main/java/com/zelusik/eatery/app/constant/place/PlaceSearchKeyword.java
@@ -1,7 +1,6 @@
 package com.zelusik.eatery.app.constant.place;
 
 import com.zelusik.eatery.global.exception.place.NotAcceptablePlaceSearchKeyword;
-import com.zelusik.eatery.global.exception.review.NotAcceptableReviewKeyword;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,8 +27,12 @@ public enum PlaceSearchKeyword {
     private final String description;
 
     public static PlaceSearchKeyword valueOfDescription(String description) {
+        String trimmedDescription = description.replace(" ", "");
+
         return Arrays.stream(values())
-                .filter(value -> description.equals(value.getDescription()))
+                .filter(value -> trimmedDescription.equals(
+                        value.getDescription().replace(" ", "")
+                ))
                 .findFirst()
                 .orElseThrow(NotAcceptablePlaceSearchKeyword::new);
     }

--- a/src/main/java/com/zelusik/eatery/app/constant/review/ReviewKeyword.java
+++ b/src/main/java/com/zelusik/eatery/app/constant/review/ReviewKeyword.java
@@ -43,9 +43,12 @@ public enum ReviewKeyword {
     private final String description;
 
     public static ReviewKeyword valueOfDescription(String description) {
+        String trimmedDescription = description.replace(" ", "");
+
         return Arrays.stream(values())
-                .filter(value -> description.equals(value.getDescription()))
-                .findFirst()
+                .filter(value -> trimmedDescription.equals(
+                        value.getDescription().replace(" ", "")
+                )).findFirst()
                 .orElseThrow(NotAcceptableReviewKeyword::new);
     }
 }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #61

## 🏃‍ Task
- Enum class의 한글<=>영어 변환 로직(valueOfDescription)이 공백에 상관없이 동작하도록 구현

## 📄 Reference
- `PlaceSearchhKeyword`
- `ReviewKeyword`
- `FoodCategory`

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
