### PR TITLE
회원 프로필 이미지 구현

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/constant/ConstantUtil.java
+++ b/src/main/java/com/zelusik/eatery/app/constant/ConstantUtil.java
@@ -1,0 +1,7 @@
+package com.zelusik.eatery.app.constant;
+
+public class ConstantUtil {
+
+    public static final String defaultProfileImageUrl = "https://oopy.lazyrockets.com/api/v2/notion/image?src=https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F1558fc9e-fdfe-4804-b6e7-47a9d0e746de%2Fcmc_bread_white_small_logo.png&blockId=693ceac0-67fd-4bdc-afb9-b172f9aef66b&width=256";
+    public static final String defaultProfileThumbnailImageUrl = "https://oopy.lazyrockets.com/api/v2/notion/image?src=https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F1558fc9e-fdfe-4804-b6e7-47a9d0e746de%2Fcmc_bread_white_small_logo.png&blockId=693ceac0-67fd-4bdc-afb9-b172f9aef66b&width=256";
+}

--- a/src/main/java/com/zelusik/eatery/app/domain/Review.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/Review.java
@@ -2,6 +2,7 @@ package com.zelusik.eatery.app.domain;
 
 
 import com.zelusik.eatery.app.constant.review.ReviewKeyword;
+import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.place.Place;
 import com.zelusik.eatery.app.util.domain.ReviewKeywordsConverter;
 import lombok.AccessLevel;

--- a/src/main/java/com/zelusik/eatery/app/domain/member/Member.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/member/Member.java
@@ -1,8 +1,10 @@
-package com.zelusik.eatery.app.domain;
+package com.zelusik.eatery.app.domain.member;
 
 import com.zelusik.eatery.app.constant.FoodCategory;
 import com.zelusik.eatery.app.constant.member.Gender;
 import com.zelusik.eatery.app.constant.member.LoginType;
+import com.zelusik.eatery.app.domain.BaseTimeEntity;
+import com.zelusik.eatery.app.domain.TermsInfo;
 import com.zelusik.eatery.app.util.domain.FoodCategoryConverter;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
@@ -27,6 +29,12 @@ public class Member extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private TermsInfo termsInfo;
 
+    @Column(nullable = false)
+    private String profileImageUrl;
+
+    @Column(nullable = false)
+    private String profileThumbnailImageUrl;
+
     @Column(nullable = false, unique = true)
     private String socialUid;
 
@@ -34,6 +42,7 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private LoginType loginType;
 
+    @Column(unique = true)
     private String email;
 
     @Column(nullable = false)
@@ -50,14 +59,16 @@ public class Member extends BaseTimeEntity {
 
     private LocalDateTime deletedAt;
 
-    public static Member of(String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender) {
-        return of(null, null, socialUid, loginType, email, nickname, ageRange, gender, null, null, null, null);
+    public static Member of(String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender) {
+        return of(null, null, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, email, nickname, ageRange, gender, null, null, null, null);
     }
 
-    public static Member of(Long id, TermsInfo termsInfo, String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender, List<FoodCategory> favoriteFoodCategories, LocalDateTime deletedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public static Member of(Long id, TermsInfo termsInfo, String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender, List<FoodCategory> favoriteFoodCategories, LocalDateTime deletedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
         return Member.builder()
                 .id(id)
                 .termsInfo(termsInfo)
+                .profileImageUrl(profileImageUrl)
+                .profileThumbnailImageUrl(profileThumbnailImageUrl)
                 .socialUid(socialUid)
                 .loginType(loginType)
                 .email(email)
@@ -72,10 +83,12 @@ public class Member extends BaseTimeEntity {
     }
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Member(Long id, TermsInfo termsInfo, String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender, List<FoodCategory> favoriteFoodCategories, LocalDateTime deletedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private Member(Long id, TermsInfo termsInfo, String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender, List<FoodCategory> favoriteFoodCategories, LocalDateTime deletedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
         super(createdAt, updatedAt);
         this.id = id;
         this.termsInfo = termsInfo;
+        this.profileImageUrl = profileImageUrl;
+        this.profileThumbnailImageUrl = profileThumbnailImageUrl;
         this.socialUid = socialUid;
         this.loginType = loginType;
         this.email = email;

--- a/src/main/java/com/zelusik/eatery/app/domain/member/ProfileImage.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/member/ProfileImage.java
@@ -1,0 +1,55 @@
+package com.zelusik.eatery.app.domain.member;
+
+import com.zelusik.eatery.app.domain.S3File;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@SQLDelete(sql = "UPDATE profile_image SET deleted_at = CURRENT_TIMESTAMP WHERE profile_image_id = ?")
+@Entity
+public class ProfileImage extends S3File {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "profile_image_id")
+    private Long id;
+
+    @JoinColumn(name = "member_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    public static ProfileImage of(Member member, String originalName, String storedName, String url) {
+        return ProfileImage.builder()
+                .member(member)
+                .originalName(originalName)
+                .storedName(storedName)
+                .url(url)
+                .build();
+    }
+
+    public static ProfileImage of(Long id, Member member, String originalName, String storedName, String url, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        return ProfileImage.builder()
+                .id(id)
+                .member(member)
+                .originalName(originalName)
+                .storedName(storedName)
+                .url(url)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .deletedAt(deletedAt)
+                .build();
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ProfileImage(Long id, Member member, String originalName, String storedName, String url, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        super(originalName, storedName, url, createdAt, updatedAt, deletedAt);
+        this.id = id;
+    }
+}

--- a/src/main/java/com/zelusik/eatery/app/dto/auth/KakaoOAuthUserInfo.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/auth/KakaoOAuthUserInfo.java
@@ -1,5 +1,6 @@
 package com.zelusik.eatery.app.dto.auth;
 
+import com.zelusik.eatery.app.constant.ConstantUtil;
 import com.zelusik.eatery.app.constant.member.Gender;
 import com.zelusik.eatery.app.constant.member.LoginType;
 import com.zelusik.eatery.app.dto.member.MemberDto;
@@ -87,7 +88,19 @@ public record KakaoOAuthUserInfo(
     }
 
     public MemberDto toMemberDto() {
+        String profileImageUrl = getProfileImageUrl();
+        if (profileImageUrl == null) {
+            profileImageUrl = ConstantUtil.defaultProfileImageUrl;
+        }
+
+        String thumbnailImageUrl = getThumbnailImageUrl();
+        if (thumbnailImageUrl == null) {
+            thumbnailImageUrl = ConstantUtil.defaultProfileThumbnailImageUrl;
+        }
+
         return MemberDto.of(
+                profileImageUrl,
+                thumbnailImageUrl,
                 getSocialUid(),
                 LoginType.KAKAO,
                 getEmail(),

--- a/src/main/java/com/zelusik/eatery/app/dto/member/MemberDto.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/member/MemberDto.java
@@ -1,9 +1,9 @@
 package com.zelusik.eatery.app.dto.member;
 
 import com.zelusik.eatery.app.constant.FoodCategory;
-import com.zelusik.eatery.app.domain.Member;
 import com.zelusik.eatery.app.constant.member.Gender;
 import com.zelusik.eatery.app.constant.member.LoginType;
+import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.dto.terms_info.TermsInfoDto;
 
 import java.time.LocalDateTime;
@@ -12,6 +12,8 @@ import java.util.List;
 public record MemberDto(
         Long id,
         TermsInfoDto termsInfoDto,
+        String profileImageUrl,
+        String profileThumbnailImageUrl,
         String socialUid,
         LoginType loginType,
         String email,
@@ -23,18 +25,20 @@ public record MemberDto(
         LocalDateTime updatedAt,
         LocalDateTime deletedAt
 ) {
-    public static MemberDto of(String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender) {
-        return of(null, null, socialUid, loginType, email, nickname, ageRange, gender, null, null, null, null);
+    public static MemberDto of(String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender) {
+        return of(null, null, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, email, nickname, ageRange, gender, null, null, null, null);
     }
 
-    public static MemberDto of(Long id, TermsInfoDto termsInfoDto, String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender, List<FoodCategory> favoriteFoodCategories, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
-        return new MemberDto(id, termsInfoDto, socialUid, loginType, email, nickname, ageRange, gender, favoriteFoodCategories, createdAt, updatedAt, deletedAt);
+    public static MemberDto of(Long id, TermsInfoDto termsInfoDto, String profileImageUrl, String profileThumbnailImageUrl, String socialUid, LoginType loginType, String email, String nickname, Integer ageRange, Gender gender, List<FoodCategory> favoriteFoodCategories, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        return new MemberDto(id, termsInfoDto, profileImageUrl, profileThumbnailImageUrl, socialUid, loginType, email, nickname, ageRange, gender, favoriteFoodCategories, createdAt, updatedAt, deletedAt);
     }
 
     public static MemberDto from(Member entity) {
         return of(
                 entity.getId(),
                 TermsInfoDto.from(entity.getTermsInfo()),
+                entity.getProfileImageUrl(),
+                entity.getProfileThumbnailImageUrl(),
                 entity.getSocialUid(),
                 entity.getLoginType(),
                 entity.getEmail(),
@@ -50,6 +54,8 @@ public record MemberDto(
 
     public Member toEntity() {
         return Member.of(
+                profileImageUrl(),
+                profileThumbnailImageUrl(),
                 socialUid(),
                 loginType(),
                 email(),

--- a/src/main/java/com/zelusik/eatery/app/dto/member/response/LoggedInMemberResponse.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/member/response/LoggedInMemberResponse.java
@@ -18,6 +18,12 @@ public class LoggedInMemberResponse {
     @Schema(description = "약관 동의 정보")
     private TermsInfoResponse termsInfo;
 
+    @Schema(description = "프로필 이미지 url", example = "https://...")
+    private String profileImageUrl;
+
+    @Schema(description = "프로필 이미지 썸네일 url", example = "https://...")
+    private String profileThumbnailImageUrl;
+
     @Schema(description = "로그인 유형", example = "KAKAO")
     private LoginType loginType;
 
@@ -31,6 +37,8 @@ public class LoggedInMemberResponse {
         return new LoggedInMemberResponse(
                 memberDto.id(),
                 TermsInfoResponse.from(memberDto.termsInfoDto()),
+                memberDto.profileImageUrl(),
+                memberDto.profileThumbnailImageUrl(),
                 memberDto.loginType(),
                 memberDto.email(),
                 memberDto.nickname()

--- a/src/main/java/com/zelusik/eatery/app/dto/member/response/MemberResponse.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/member/response/MemberResponse.java
@@ -3,7 +3,6 @@ package com.zelusik.eatery.app.dto.member.response;
 import com.zelusik.eatery.app.constant.FoodCategory;
 import com.zelusik.eatery.app.constant.member.Gender;
 import com.zelusik.eatery.app.dto.member.MemberDto;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,6 +17,12 @@ public class MemberResponse {
     @Schema(description = "회원 id(PK)", example = "1")
     private Long id;
 
+    @Schema(description = "프로필 이미지 url", example = "https://...")
+    private String profileImageUrl;
+
+    @Schema(description = "프로필 이미지 썸네일 url", example = "https://...")
+    private String profileThumbnailImageUrl;
+
     @Schema(description = "이메일", example = "eatery@gmail.com")
     private String email;
 
@@ -30,9 +35,11 @@ public class MemberResponse {
     @Schema(description = "선호 음식 카테고리 목록", example = "[\"신선한 재료\", \"최고의 맛\"]")
     private List<String> favoriteFoodCategories;
 
-    public static MemberResponse of(Long id, String email, String nickname, Gender gender, List<FoodCategory> favoriteFoodCategories) {
+    public static MemberResponse of(Long id, String profileImageUrl, String profileThumbnailImageUrl, String email, String nickname, Gender gender, List<FoodCategory> favoriteFoodCategories) {
         return new MemberResponse(
                 id,
+                profileImageUrl,
+                profileThumbnailImageUrl,
                 email,
                 nickname,
                 gender.getDescription(),
@@ -45,6 +52,8 @@ public class MemberResponse {
     public static MemberResponse from(MemberDto dto) {
         return of(
                 dto.id(),
+                dto.profileImageUrl(),
+                dto.profileThumbnailImageUrl(),
                 dto.email(),
                 dto.nickname(),
                 dto.gender(),

--- a/src/main/java/com/zelusik/eatery/app/dto/review/ReviewDtoWithMemberAndPlace.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/review/ReviewDtoWithMemberAndPlace.java
@@ -1,6 +1,6 @@
 package com.zelusik.eatery.app.dto.review;
 
-import com.zelusik.eatery.app.domain.Member;
+import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.Review;
 import com.zelusik.eatery.app.constant.review.ReviewKeyword;
 import com.zelusik.eatery.app.domain.place.Place;

--- a/src/main/java/com/zelusik/eatery/app/repository/MemberRepository.java
+++ b/src/main/java/com/zelusik/eatery/app/repository/MemberRepository.java
@@ -1,6 +1,6 @@
 package com.zelusik.eatery.app.repository;
 
-import com.zelusik.eatery.app.domain.Member;
+import com.zelusik.eatery.app.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/zelusik/eatery/app/service/MemberService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/MemberService.java
@@ -1,7 +1,7 @@
 package com.zelusik.eatery.app.service;
 
 import com.zelusik.eatery.app.constant.FoodCategory;
-import com.zelusik.eatery.app.domain.Member;
+import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.TermsInfo;
 import com.zelusik.eatery.app.dto.member.MemberDto;
 import com.zelusik.eatery.app.dto.member.request.TermsAgreeRequest;

--- a/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
@@ -1,6 +1,6 @@
 package com.zelusik.eatery.app.service;
 
-import com.zelusik.eatery.app.domain.Member;
+import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.Review;
 import com.zelusik.eatery.app.domain.place.Place;
 import com.zelusik.eatery.app.dto.place.PlaceDto;

--- a/src/main/java/com/zelusik/eatery/global/exception/ExceptionType.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/ExceptionType.java
@@ -1,6 +1,6 @@
 package com.zelusik.eatery.global.exception;
 
-import com.zelusik.eatery.app.domain.Member;
+import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.Review;
 import com.zelusik.eatery.app.domain.curation.Curation;
 import com.zelusik.eatery.app.domain.place.Place;

--- a/src/test/java/com/zelusik/eatery/app/dto/auth/KakaoOAuthUserInfoTest.java
+++ b/src/test/java/com/zelusik/eatery/app/dto/auth/KakaoOAuthUserInfoTest.java
@@ -72,6 +72,8 @@ class KakaoOAuthUserInfoTest {
         assertThat(result.getEmail()).isEqualTo("test@kakao.com");
         assertThat(result.getAgeRange()).isEqualTo(20);
         assertThat(result.getGender()).isEqualTo(Gender.MALE);
+        assertThat(result.getProfileImageUrl()).isEqualTo("https://oopy.lazyrockets.com/api/v2/notion/image?src=https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F1558fc9e-fdfe-4804-b6e7-47a9d0e746de%2Fcmc_bread_white_small_logo.png&blockId=693ceac0-67fd-4bdc-afb9-b172f9aef66b&width=256");
+        assertThat(result.getThumbnailImageUrl()).isEqualTo("https://oopy.lazyrockets.com/api/v2/notion/image?src=https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F1558fc9e-fdfe-4804-b6e7-47a9d0e746de%2Fcmc_bread_white_small_logo.png&blockId=693ceac0-67fd-4bdc-afb9-b172f9aef66b&width=256");
     }
     
     @DisplayName("필수 동의 항목만 동의한 kakao 유저 정보가 주어지면 해당하는 내용으로 KakaoOAuthInfo 객체로 변환한다.")
@@ -119,5 +121,7 @@ class KakaoOAuthUserInfoTest {
         assertThat(result.getEmail()).isNull();
         assertThat(result.getAgeRange()).isNull();
         assertThat(result.getGender()).isNull();
+        assertThat(result.getProfileImageUrl()).isNull();
+        assertThat(result.getThumbnailImageUrl()).isNull();
     }
 }

--- a/src/test/java/com/zelusik/eatery/app/service/MemberServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/app/service/MemberServiceTest.java
@@ -1,7 +1,7 @@
 package com.zelusik.eatery.app.service;
 
 import com.zelusik.eatery.app.constant.FoodCategory;
-import com.zelusik.eatery.app.domain.Member;
+import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.TermsInfo;
 import com.zelusik.eatery.app.dto.member.MemberDto;
 import com.zelusik.eatery.app.dto.member.request.TermsAgreeRequest;

--- a/src/test/java/com/zelusik/eatery/app/service/ReviewServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/app/service/ReviewServiceTest.java
@@ -1,6 +1,6 @@
 package com.zelusik.eatery.app.service;
 
-import com.zelusik.eatery.app.domain.Member;
+import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.Review;
 import com.zelusik.eatery.app.domain.place.Place;
 import com.zelusik.eatery.app.dto.review.ReviewDtoWithMember;

--- a/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
@@ -1,11 +1,11 @@
 package com.zelusik.eatery.util;
 
+import com.zelusik.eatery.app.constant.ConstantUtil;
 import com.zelusik.eatery.app.constant.FoodCategory;
-import com.zelusik.eatery.app.domain.Member;
+import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.constant.member.Gender;
 import com.zelusik.eatery.app.constant.member.LoginType;
 import com.zelusik.eatery.app.dto.member.MemberDto;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,6 +20,8 @@ public class MemberTestUtils {
 
     public static MemberDto createMemberDto() {
         return MemberDto.of(
+                ConstantUtil.defaultProfileImageUrl,
+                ConstantUtil.defaultProfileThumbnailImageUrl,
                 SOCIAL_UID,
                 LoginType.KAKAO,
                 EMAIL,
@@ -33,6 +35,8 @@ public class MemberTestUtils {
         return MemberDto.of(
                 1L,
                 null,
+                ConstantUtil.defaultProfileImageUrl,
+                ConstantUtil.defaultProfileThumbnailImageUrl,
                 SOCIAL_UID,
                 LoginType.KAKAO,
                 EMAIL,
@@ -50,6 +54,8 @@ public class MemberTestUtils {
         return Member.of(
                 memberId,
                 null,
+                ConstantUtil.defaultProfileImageUrl,
+                ConstantUtil.defaultProfileThumbnailImageUrl,
                 SOCIAL_UID,
                 LoginType.KAKAO,
                 EMAIL,

--- a/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
@@ -1,7 +1,7 @@
 package com.zelusik.eatery.util;
 
 import com.zelusik.eatery.app.constant.review.ReviewKeyword;
-import com.zelusik.eatery.app.domain.Member;
+import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.Review;
 import com.zelusik.eatery.app.domain.place.Place;
 import com.zelusik.eatery.app.dto.review.ReviewDtoWithMember;


### PR DESCRIPTION
## 🔥 Related Issue
- Close #64

## 🏃‍ Task
- 필요한 domain class 구현
- 카카오 로그인 중 회원가입 시 profileImageUrl을 읽어서 저장할 수 있도록 구현
- 응답 데이터에 프로필 이미지 추가

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
