### PR TITLE
회원 탈퇴 API 구현 - 회원 탈퇴 시 설문 응답 받도록 추가 구현

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/constant/review/MemberDeletionSurveyType.java
+++ b/src/main/java/com/zelusik/eatery/app/constant/review/MemberDeletionSurveyType.java
@@ -1,0 +1,28 @@
+package com.zelusik.eatery.app.constant.review;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "<p>회원 탈퇴 설문 응답. 목록은 다음과 같다." +
+        "<ul>" +
+        "<li>HARD_TO_WRITE - 스토리/탭탭리뷰를 작성하기가 어렵고 불편함</li>" +
+        "<li>FEED_UNUSEFUL - 피드의 추천이 유용하지 않음</li>" +
+        "<li>REVIEW_NOT_ENOUGH - 리뷰가 많지 않아 도움되지 않음</li>" +
+        "<li>NOT_MEET_EXPECTATION - 다운로드 시 기대한 내용과 앱이 다름</li>" +
+        "<li>NOT_TRUST - 서비스 운영의 신뢰도가 낮음</li>" +
+        "<li>ETC - 기타</li>" +
+        "</ul>")
+@AllArgsConstructor
+@Getter
+public enum MemberDeletionSurveyType {
+
+    HARD_TO_WRITE("스토리/탭탭리뷰를 작성하기가 어렵고 불편함"),
+    FEED_UNUSEFUL("피드의 추천이 유용하지 않음"),
+    REVIEW_NOT_ENOUGH("리뷰가 많지 않아 도움되지 않음"),
+    NOT_MEET_EXPECTATION("다운로드 시 기대한 내용과 앱이 다름"),
+    NOT_TRUST("서비스 운영의 신뢰도가 낮음"),
+    ETC("기타");
+
+    private final String description;
+}

--- a/src/main/java/com/zelusik/eatery/app/controller/MemberController.java
+++ b/src/main/java/com/zelusik/eatery/app/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.zelusik.eatery.app.controller;
 
 import com.zelusik.eatery.app.constant.FoodCategory;
+import com.zelusik.eatery.app.dto.member.MemberDeletionSurveyDto;
 import com.zelusik.eatery.app.dto.member.request.FavoriteFoodCategoriesUpdateRequest;
 import com.zelusik.eatery.app.dto.member.request.MemberUpdateRequest;
 import com.zelusik.eatery.app.dto.member.request.TermsAgreeRequest;
 import com.zelusik.eatery.app.dto.member.response.MemberResponse;
+import com.zelusik.eatery.app.dto.review.request.MemberDeletionSurveyRequest;
 import com.zelusik.eatery.app.dto.terms_info.response.TermsInfoResponse;
 import com.zelusik.eatery.app.service.MemberService;
 import com.zelusik.eatery.global.security.UserPrincipal;
@@ -108,7 +110,10 @@ public class MemberController {
             security = @SecurityRequirement(name = "access-token")
     )
     @DeleteMapping
-    public void delete(@Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        memberService.delete(userPrincipal.getMemberId());
+    public MemberDeletionSurveyDto delete(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody MemberDeletionSurveyRequest memberDeletionSurveyRequest
+    ) {
+        return memberService.delete(userPrincipal.getMemberId(), memberDeletionSurveyRequest.getSurveyType());
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/controller/ReviewController.java
+++ b/src/main/java/com/zelusik/eatery/app/controller/ReviewController.java
@@ -1,6 +1,8 @@
 package com.zelusik.eatery.app.controller;
 
 import com.zelusik.eatery.app.dto.SliceResponse;
+import com.zelusik.eatery.app.dto.member.MemberDeletionSurveyDto;
+import com.zelusik.eatery.app.dto.review.request.MemberDeletionSurveyRequest;
 import com.zelusik.eatery.app.dto.review.request.ReviewCreateRequest;
 import com.zelusik.eatery.app.dto.review.response.FeedResponse;
 import com.zelusik.eatery.app.dto.review.response.ReviewListElemResponse;

--- a/src/main/java/com/zelusik/eatery/app/domain/member/MemberDeletionSurvey.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/member/MemberDeletionSurvey.java
@@ -1,0 +1,54 @@
+package com.zelusik.eatery.app.domain.member;
+
+import com.zelusik.eatery.app.constant.review.MemberDeletionSurveyType;
+import com.zelusik.eatery.app.domain.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class MemberDeletionSurvey extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_deletion_survey_id")
+    private Long id;
+
+    @JoinColumn(name = "member_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Column(nullable = false)
+    private MemberDeletionSurveyType surveyType;
+
+    public static MemberDeletionSurvey of(Member member, MemberDeletionSurveyType surveyType) {
+        return MemberDeletionSurvey.builder()
+                .member(member)
+                .surveyType(surveyType)
+                .build();
+    }
+
+    public static MemberDeletionSurvey of(Long id, Member member, MemberDeletionSurveyType surveyType, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return MemberDeletionSurvey.builder()
+                .id(id)
+                .member(member)
+                .surveyType(surveyType)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private MemberDeletionSurvey(Long id, Member member, MemberDeletionSurveyType surveyType, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        super(createdAt, updatedAt);
+        this.id = id;
+        this.member = member;
+        this.surveyType = surveyType;
+    }
+}

--- a/src/main/java/com/zelusik/eatery/app/dto/member/MemberDeletionSurveyDto.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/member/MemberDeletionSurveyDto.java
@@ -1,0 +1,22 @@
+package com.zelusik.eatery.app.dto.member;
+
+import com.zelusik.eatery.app.constant.review.MemberDeletionSurveyType;
+import com.zelusik.eatery.app.domain.member.MemberDeletionSurvey;
+
+public record MemberDeletionSurveyDto(
+        Long id,
+        Long memberId,
+        MemberDeletionSurveyType surveyType
+) {
+    public static MemberDeletionSurveyDto of(Long id, Long memberId, MemberDeletionSurveyType surveyType) {
+        return new MemberDeletionSurveyDto(id, memberId, surveyType);
+    }
+
+    public static MemberDeletionSurveyDto from(MemberDeletionSurvey entity) {
+        return of(
+                entity.getId(),
+                entity.getId(),
+                entity.getSurveyType()
+        );
+    }
+}

--- a/src/main/java/com/zelusik/eatery/app/dto/member/response/MemberDeletionSurveyResponse.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/member/response/MemberDeletionSurveyResponse.java
@@ -1,0 +1,29 @@
+package com.zelusik.eatery.app.dto.member.response;
+
+import com.zelusik.eatery.app.dto.member.MemberDeletionSurveyDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class MemberDeletionSurveyResponse {
+
+    @Schema(description = "회원 탈퇴 설문의 PK", example = "3")
+    private Long id;
+
+    @Schema(description = "회원의 PK", example = "1")
+    private Long memberId;
+
+    @Schema(description = "설문 내용", example = "스토리/탭탭리뷰를 작성하기가 어렵고 불편함")
+    private String survey;
+
+    public static MemberDeletionSurveyResponse of(Long id, Long memberId, String surveyType) {
+        return new MemberDeletionSurveyResponse(id, memberId, surveyType);
+    }
+
+    public static MemberDeletionSurveyResponse from(MemberDeletionSurveyDto dto) {
+        return of(dto.id(), dto.memberId(), dto.surveyType().getDescription());
+    }
+}

--- a/src/main/java/com/zelusik/eatery/app/dto/review/request/MemberDeletionSurveyRequest.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/review/request/MemberDeletionSurveyRequest.java
@@ -1,0 +1,15 @@
+package com.zelusik.eatery.app.dto.review.request;
+
+import com.zelusik.eatery.app.constant.review.MemberDeletionSurveyType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class MemberDeletionSurveyRequest {
+
+    @Schema(description = "회원 탈퇴 설문 응답", example = "HARD_TO_WRITE")
+    @NotNull
+    private MemberDeletionSurveyType surveyType;
+}

--- a/src/main/java/com/zelusik/eatery/app/repository/MemberDeletionSurveyRepository.java
+++ b/src/main/java/com/zelusik/eatery/app/repository/MemberDeletionSurveyRepository.java
@@ -1,0 +1,7 @@
+package com.zelusik.eatery.app.repository;
+
+import com.zelusik.eatery.app.domain.member.MemberDeletionSurvey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberDeletionSurveyRepository extends JpaRepository<MemberDeletionSurvey, Long> {
+}

--- a/src/main/java/com/zelusik/eatery/app/service/MemberService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/MemberService.java
@@ -1,13 +1,17 @@
 package com.zelusik.eatery.app.service;
 
 import com.zelusik.eatery.app.constant.FoodCategory;
+import com.zelusik.eatery.app.constant.review.MemberDeletionSurveyType;
 import com.zelusik.eatery.app.domain.TermsInfo;
 import com.zelusik.eatery.app.domain.member.Member;
+import com.zelusik.eatery.app.domain.member.MemberDeletionSurvey;
 import com.zelusik.eatery.app.domain.member.ProfileImage;
+import com.zelusik.eatery.app.dto.member.MemberDeletionSurveyDto;
 import com.zelusik.eatery.app.dto.member.MemberDto;
 import com.zelusik.eatery.app.dto.member.request.MemberUpdateRequest;
 import com.zelusik.eatery.app.dto.member.request.TermsAgreeRequest;
 import com.zelusik.eatery.app.dto.terms_info.TermsInfoDto;
+import com.zelusik.eatery.app.repository.MemberDeletionSurveyRepository;
 import com.zelusik.eatery.app.repository.MemberRepository;
 import com.zelusik.eatery.app.repository.TermsInfoRepository;
 import com.zelusik.eatery.global.exception.member.MemberIdNotFoundException;
@@ -28,6 +32,7 @@ public class MemberService {
     private final ProfileImageService profileImageService;
     private final MemberRepository memberRepository;
     private final TermsInfoRepository termsInfoRepository;
+    private final MemberDeletionSurveyRepository memberDeletionSurveyRepository;
 
     /**
      * 회원 정보를 전달받아 회원가입을 진행한다.
@@ -174,8 +179,14 @@ public class MemberService {
      * @param memberId 삭제할 회원의 PK
      */
     @Transactional
-    public void delete(Long memberId) {
+    public MemberDeletionSurveyDto delete(Long memberId, MemberDeletionSurveyType surveyType) {
         Member member = findEntityById(memberId);
         memberRepository.delete(member);
+
+        return MemberDeletionSurveyDto.from(
+                memberDeletionSurveyRepository.save(
+                        MemberDeletionSurvey.of(member, surveyType)
+                )
+        );
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
@@ -1,13 +1,17 @@
 package com.zelusik.eatery.app.service;
 
-import com.zelusik.eatery.app.domain.member.Member;
+import com.zelusik.eatery.app.constant.review.MemberDeletionSurveyType;
 import com.zelusik.eatery.app.domain.Review;
+import com.zelusik.eatery.app.domain.member.Member;
+import com.zelusik.eatery.app.domain.member.MemberDeletionSurvey;
 import com.zelusik.eatery.app.domain.place.Place;
+import com.zelusik.eatery.app.dto.member.MemberDeletionSurveyDto;
 import com.zelusik.eatery.app.dto.place.PlaceDto;
 import com.zelusik.eatery.app.dto.place.request.PlaceCreateRequest;
 import com.zelusik.eatery.app.dto.review.ReviewDtoWithMember;
 import com.zelusik.eatery.app.dto.review.ReviewDtoWithMemberAndPlace;
 import com.zelusik.eatery.app.dto.review.request.ReviewCreateRequest;
+import com.zelusik.eatery.app.repository.MemberDeletionSurveyRepository;
 import com.zelusik.eatery.app.repository.ReviewRepository;
 import com.zelusik.eatery.global.exception.review.ReviewDeletePermissionDeniedException;
 import com.zelusik.eatery.global.exception.review.ReviewNotFoundException;


### PR DESCRIPTION
## 🔥 Related Issue
- Close #41

## 🏃‍ Task
- 회원 탈퇴 시 설문 응답 받도록 추가 구현

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
