### PR TITLE
Place top 3 keywords 계산할 때 삭제된 리뷰는 제외하고 계산하도록 변경, 리뷰 삭제 시 top 3 keyword 갱신하도록 로직 추가.

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/dto/place/response/PlaceResponse.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/place/response/PlaceResponse.java
@@ -19,7 +19,11 @@ public class PlaceResponse {
     @Schema(description = "장소의 id(PK)", example = "1")
     private Long id;
 
-    @Schema(description = "가장 많이 태그된 top 3 keywords", example = "[\"신선한 재료\", \"최고의 맛\"]")
+    @Schema(
+            description = "<p>가장 많이 태그된 top 3 keywords." +
+                    "<p>이 장소에 대한 리뷰가 없다면, empty array로 응답합니다.",
+            example = "[\"신선한 재료\", \"최고의 맛\"]"
+    )
     List<String> top3Keywords;
 
     @Schema(description = "이름", example = "연남토마 본점")

--- a/src/main/java/com/zelusik/eatery/app/repository/review/ReviewKeywordJdbcTemplateRepositoryImpl.java
+++ b/src/main/java/com/zelusik/eatery/app/repository/review/ReviewKeywordJdbcTemplateRepositoryImpl.java
@@ -20,9 +20,10 @@ public class ReviewKeywordJdbcTemplateRepositoryImpl implements ReviewKeywordJdb
     public List<ReviewKeywordValue> searchTop3Keywords(Long placeId) {
         String sql = "SELECT rk.keyword " +
                 "FROM review r " +
-                "JOIN place p on r.place_id = p.place_id " +
-                "JOIN review_keyword rk on r.review_id = rk.review_id " +
+                "JOIN place p ON r.place_id = p.place_id " +
+                "JOIN review_keyword rk ON r.review_id = rk.review_id " +
                 "WHERE p.place_id = :place_id " +
+                "AND r.deleted_at IS NULL " +
                 "GROUP BY rk.keyword " +
                 "ORDER BY COUNT(rk.keyword) DESC " +
                 "LIMIT 3";

--- a/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
@@ -69,8 +69,7 @@ public class ReviewService {
         reviewFileService.upload(review, files);
 
         // 장소 top 3 keyword 설정
-        List<ReviewKeywordValue> placeTop3Keywords = reviewKeywordRepository.searchTop3Keywords(place.getId());
-        place.setTop3Keywords(placeTop3Keywords);
+        renewPlaceTop3Keywords(place);
 
         return ReviewDtoWithMemberAndPlace.from(review, markedPlaceIdList);
     }
@@ -159,6 +158,9 @@ public class ReviewService {
 
         reviewFileService.deleteAll(review.getReviewFiles());
         reviewRepository.delete(review);
+        reviewRepository.flush();
+
+        renewPlaceTop3Keywords(review.getPlace());
     }
 
     /**
@@ -185,5 +187,15 @@ public class ReviewService {
         if (!review.getWriter().getId().equals(member.getId())) {
             throw new ReviewDeletePermissionDeniedException();
         }
+    }
+
+    /**
+     * 장소의 top 3 keyword를 DB에서 조회 후 갱신한다.
+     *
+     * @param place top 3 keyword를 갱신할 장소
+     */
+    private void renewPlaceTop3Keywords(Place place) {
+        List<ReviewKeywordValue> placeTop3Keywords = reviewKeywordRepository.searchTop3Keywords(place.getId());
+        place.setTop3Keywords(placeTop3Keywords);
     }
 }

--- a/src/test/java/com/zelusik/eatery/app/repository/place/PlaceRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/app/repository/place/PlaceRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.zelusik.eatery.app.repository.place;
 
+import com.zelusik.eatery.app.config.QuerydslConfig;
 import com.zelusik.eatery.app.constant.place.DayOfWeek;
 import com.zelusik.eatery.app.domain.place.Place;
 import com.zelusik.eatery.app.domain.place.Point;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -23,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("[Repository] Place")
 @ActiveProfiles("test")
+@Import(QuerydslConfig.class)
 @DataJpaTest
 class PlaceRepositoryTest {
 

--- a/src/test/java/com/zelusik/eatery/util/PlaceTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/PlaceTestUtils.java
@@ -2,6 +2,7 @@ package com.zelusik.eatery.util;
 
 import com.zelusik.eatery.app.constant.place.DayOfWeek;
 import com.zelusik.eatery.app.constant.place.KakaoCategoryGroupCode;
+import com.zelusik.eatery.app.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.app.domain.place.*;
 import com.zelusik.eatery.app.dto.place.OpeningHoursDto;
 import com.zelusik.eatery.app.dto.place.PlaceDto;
@@ -32,6 +33,7 @@ public class PlaceTestUtils {
     public static PlaceDto createPlaceDtoWithIdAndOpeningHours() {
         return PlaceDto.of(
                 1L,
+                List.of(ReviewKeywordValue.FRESH),
                 "308342289",
                 "연남토마 본점",
                 "http://place.map.kakao.com/308342289",
@@ -69,6 +71,7 @@ public class PlaceTestUtils {
     public static Place createPlace(Long id, String homepageUrl, String lat, String lng, String closingHours) {
         return Place.of(
                 id,
+                List.of(ReviewKeywordValue.FRESH),
                 "308342289",
                 "연남토마 본점",
                 "http://place.map.kakao.com/308342289",


### PR DESCRIPTION
## 🔥 Related Issue
- Close #79 

## 🏃‍ Task
- Place top 3 keywords 계산할 때 삭제된 리뷰는 제외하고 계산하도록 변경
- 리뷰 삭제 시 top 3 keyword 갱신하도록 로직 추가.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x] Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 팀의 코딩 컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x] 관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
