### PR TITLE
Apple login 과정 중 일치하는 공개키를 찾지 못했을 경우 identity token 관련 에러를 응답하도록 변경

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/dto/auth/AppleOAuthPublicKey.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/auth/AppleOAuthPublicKey.java
@@ -1,5 +1,6 @@
 package com.zelusik.eatery.app.dto.auth;
 
+import com.zelusik.eatery.global.exception.auth.TokenValidateException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -49,6 +50,7 @@ public class AppleOAuthPublicKey {
         return this.getKeys().stream()
                 .filter(key -> key.getKid().equals(kid) && key.getAlg().equals(alg))
                 .findFirst()
-                .orElseThrow(() -> new NullPointerException());
+                .orElseThrow(() ->
+                        new TokenValidateException("Apple 공개키 검증 과정에서 발생한 에러."));
     }
 }

--- a/src/main/java/com/zelusik/eatery/global/exception/auth/TokenValidateException.java
+++ b/src/main/java/com/zelusik/eatery/global/exception/auth/TokenValidateException.java
@@ -8,6 +8,10 @@ public class TokenValidateException extends UnauthorizedException {
         super();
     }
 
+    public TokenValidateException(String optionalMessage) {
+        super(optionalMessage);
+    }
+
     public TokenValidateException(Throwable cause) {
         super(cause);
     }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #87

## 🏃‍ Task
- Apple login 과정 중 일치하는 공개키를 찾지 못했을 경우 identity token 관련 에러를 응답하도록 변경

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
