### PR TITLE
fix: #101 API 요청 시 `LocalDate` 값이 들어가지 않는 버그 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/dto/member/request/MemberUpdateRequest.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/member/request/MemberUpdateRequest.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.app.dto.member.request;
 import com.zelusik.eatery.app.constant.member.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
@@ -20,6 +21,7 @@ public class MemberUpdateRequest {
     private String nickname;
 
     @Schema(description = "생년월일", example = "1998-01-05")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate birthDay;
 
     @Schema(description = "성별", example = "MALE")


### PR DESCRIPTION
## 🔥 Related Issue
- Close #101

## 🏃‍ Task
- 내 정보 수정 API 요청 시 `LocalDate` 값이 읽히지 않는 버그 수정
  - 해당 필드에 `@DateTimeFormat(pattern = "yyyy-MM-dd")` 추가

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
