### PR TITLE
리뷰 수정 시 내용(`content`)가 `null`이거나 비어있어도 에러가 발생하지 않도록 변경

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/dto/review/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/review/request/ReviewUpdateRequest.java
@@ -9,6 +9,5 @@ import javax.validation.constraints.NotBlank;
 public class ReviewUpdateRequest {
 
     @Schema(description = "수정할 내용", example = "미래에 제가 살 곳은 여기로 정했습니다. 씹을때마다 ...")
-    @NotBlank
     private String content;
 }

--- a/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
@@ -19,6 +19,7 @@ import com.zelusik.eatery.global.exception.review.ReviewUpdatePermissionDeniedEx
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -132,7 +133,7 @@ public class ReviewService {
      * @throws ReviewUpdatePermissionDeniedException 리뷰 수정 권한이 없는 경우
      */
     @Transactional
-    public ReviewDtoWithMemberAndPlace update(Long memberId, Long reviewId, String content) {
+    public ReviewDtoWithMemberAndPlace update(Long memberId, Long reviewId, @Nullable String content) {
         Review review = this.findEntityById(reviewId);
         validateReviewUpdatePermission(memberId, review);
         review.update(content);


### PR DESCRIPTION
## 🔥 Related Issue
- Close #115

## 🏃‍ Task
- 리뷰 수정 시 내용(`content`)가 `null`이거나 비어있어도 에러가 발생하지 않도록 변경

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
