### PR TITLE
리뷰 삭제 시 리뷰 키워드(`ReviewKeyword`) entity가 함께 삭제되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
@@ -158,6 +158,7 @@ public class ReviewService {
         validateReviewDeletePermission(member, review);
 
         reviewImageService.deleteAll(review.getReviewImages());
+        reviewKeywordRepository.deleteAll(review.getKeywords());
         reviewRepository.delete(review);
         reviewRepository.flush();
 


### PR DESCRIPTION
## 🔥 Related Issue
- Close #117

## 🏃‍ Task
- 리뷰 삭제 시 리뷰 키워드(`ReviewKeyword`) entity가 함께 삭제되지 않는 문제 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
