### PR TITLE
북마크에 저장한 가게 목록 조회 시 삭제된 리뷰에 있는 사진이 대표 사진으로 조회되는 버그 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/repository/place/PlaceJdbcTemplateRepositoryImpl.java
+++ b/src/main/java/com/zelusik/eatery/app/repository/place/PlaceJdbcTemplateRepositoryImpl.java
@@ -150,18 +150,21 @@ public class PlaceJdbcTemplateRepositoryImpl implements PlaceJdbcTemplateReposit
                                                                             from review_image ri
                                                                                      join review r on r.review_id = ri.review_id
                                                                             where r.place_id = p.place_id
+                                                                                and ri.deleted_at is null
                                                                             order by r.created_at desc
                                                                             limit 1 offset 0)
                          left join review_image ri2 on ri2.review_image_id = (select ri.review_image_id
                                                                             from review_image ri
                                                                                      join review r on r.review_id = ri.review_id
                                                                             where r.place_id = p.place_id
+                                                                                and ri.deleted_at is null
                                                                             order by r.created_at desc
                                                                             limit 1 offset 1)
                          left join review_image ri3 on ri3.review_image_id = (select ri.review_image_id
                                                                             from review_image ri
                                                                                      join review r on r.review_id = ri.review_id
                                                                             where r.place_id = p.place_id
+                                                                                and ri.deleted_at is null
                                                                             order by r.created_at desc
                                                                             limit 1 offset 2)
                 where bm.member_id = :member_id

--- a/src/main/java/com/zelusik/eatery/app/repository/review/ReviewKeywordJdbcTemplateRepositoryImpl.java
+++ b/src/main/java/com/zelusik/eatery/app/repository/review/ReviewKeywordJdbcTemplateRepositoryImpl.java
@@ -20,10 +20,9 @@ public class ReviewKeywordJdbcTemplateRepositoryImpl implements ReviewKeywordJdb
     public List<ReviewKeywordValue> searchTop3Keywords(Long placeId) {
         String sql = "SELECT rk.keyword " +
                 "FROM review r " +
-                "JOIN place p ON r.place_id = p.place_id " +
+                "JOIN place p ON r.place_id = p.place_id AND p.place_id = :place_id " +
                 "JOIN review_keyword rk ON r.review_id = rk.review_id " +
-                "WHERE p.place_id = :place_id " +
-                "AND r.deleted_at IS NULL " +
+                "WHERE r.deleted_at IS NULL " +
                 "GROUP BY rk.keyword " +
                 "ORDER BY COUNT(rk.keyword) DESC " +
                 "LIMIT 3";


### PR DESCRIPTION
## 🔥 Related Issue
- Close #119

## 🏃‍ Task
- 북마크에 저장한 가게 목록 조회 시 삭제된 리뷰에 있는 사진이 대표 사진으로 조회되는 버그 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]   PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
