### PR TITLE
이미지 파일 업로드 API 스펙 변경, 리뷰 생성 및 회원 정보 수정 시 이미지 생성 로직 변경

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/controller/ReviewController.java
+++ b/src/main/java/com/zelusik/eatery/app/controller/ReviewController.java
@@ -1,8 +1,6 @@
 package com.zelusik.eatery.app.controller;
 
 import com.zelusik.eatery.app.dto.SliceResponse;
-import com.zelusik.eatery.app.dto.member.MemberDeletionSurveyDto;
-import com.zelusik.eatery.app.dto.review.request.MemberDeletionSurveyRequest;
 import com.zelusik.eatery.app.dto.review.request.ReviewCreateRequest;
 import com.zelusik.eatery.app.dto.review.request.ReviewUpdateRequest;
 import com.zelusik.eatery.app.dto.review.response.FeedResponse;
@@ -56,7 +54,7 @@ public class ReviewController {
             @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @ParameterObject @Valid @ModelAttribute ReviewCreateRequest request
     ) {
-        ReviewResponse response = ReviewResponse.from(reviewService.create(userPrincipal.getMemberId(), request, request.getFiles()));
+        ReviewResponse response = ReviewResponse.from(reviewService.create(userPrincipal.getMemberId(), request, request.getImages()));
 
         return ResponseEntity
                 .created(URI.create("/api/reviews/" + response.getId()))

--- a/src/main/java/com/zelusik/eatery/app/dto/ImageDto.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/ImageDto.java
@@ -1,0 +1,22 @@
+package com.zelusik.eatery.app.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter
+@Getter
+public class ImageDto {
+
+    @Schema(description = "이미지")
+    private MultipartFile image;
+
+    @Schema(description = "리사이징된 썸네일 이미지")
+    private MultipartFile thumbnailImage;
+
+    public static ImageDto of(MultipartFile image, MultipartFile thumbnailImage) {
+        return new ImageDto(image, thumbnailImage);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/app/dto/member/request/MemberUpdateRequest.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/member/request/MemberUpdateRequest.java
@@ -1,11 +1,11 @@
 package com.zelusik.eatery.app.dto.member.request;
 
 import com.zelusik.eatery.app.constant.member.Gender;
+import com.zelusik.eatery.app.dto.ImageDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -29,9 +29,9 @@ public class MemberUpdateRequest {
     private Gender gender;
 
     @Schema(description = "변경하고자 하는 프로필 이미지")
-    private MultipartFile profileImage;
+    private ImageDto profileImage;
 
-    public static MemberUpdateRequest of(String nickname, LocalDate birthDay, Gender gender, MultipartFile profileImage) {
+    public static MemberUpdateRequest of(String nickname, LocalDate birthDay, Gender gender, ImageDto profileImage) {
         return new MemberUpdateRequest(nickname, birthDay, gender, profileImage);
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/dto/review/request/ReviewCreateRequest.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/review/request/ReviewCreateRequest.java
@@ -1,12 +1,12 @@
 package com.zelusik.eatery.app.dto.review.request;
 
 import com.zelusik.eatery.app.constant.review.ReviewKeywordValue;
+import com.zelusik.eatery.app.dto.ImageDto;
 import com.zelusik.eatery.app.dto.place.PlaceDto;
 import com.zelusik.eatery.app.dto.place.request.PlaceCreateRequest;
 import com.zelusik.eatery.app.dto.review.ReviewDtoWithMemberAndPlace;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
@@ -32,10 +32,10 @@ public class ReviewCreateRequest {
     private String content;
 
     @Schema(description = "업로드할 이미지 파일들")
-    private List<MultipartFile> files;
+    private List<ImageDto> images;
 
-    public static ReviewCreateRequest of(PlaceCreateRequest place, List<String> keywords, String autoCreatedContent, String content, List<MultipartFile> files) {
-        return new ReviewCreateRequest(place, keywords, autoCreatedContent, content, files);
+    public static ReviewCreateRequest of(PlaceCreateRequest place, List<String> keywords, String autoCreatedContent, String content, List<ImageDto> images) {
+        return new ReviewCreateRequest(place, keywords, autoCreatedContent, content, images);
     }
 
     public ReviewDtoWithMemberAndPlace toDto(PlaceDto placeDto) {

--- a/src/main/java/com/zelusik/eatery/app/service/CurationElemFileService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/CurationElemFileService.java
@@ -28,11 +28,11 @@ public class CurationElemFileService {
     public CurationElemFile upload(MultipartFile multipartFile) {
         S3ImageDto s3ImageDto = fileService.uploadImage(multipartFile, DIR_PATH);
         return curationElemFileRepository.save(CurationElemFile.of(
-                s3ImageDto.originalName(),
-                s3ImageDto.storedName(),
-                s3ImageDto.url(),
-                s3ImageDto.thumbnailStoredName(),
-                s3ImageDto.thumbnailUrl()
+                s3ImageDto.getOriginalName(),
+                s3ImageDto.getStoredName(),
+                s3ImageDto.getUrl(),
+                s3ImageDto.getThumbnailStoredName(),
+                s3ImageDto.getThumbnailUrl()
         ));
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/service/MemberService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/MemberService.java
@@ -6,6 +6,7 @@ import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.member.MemberDeletionSurvey;
 import com.zelusik.eatery.app.domain.member.ProfileImage;
 import com.zelusik.eatery.app.domain.member.TermsInfo;
+import com.zelusik.eatery.app.dto.ImageDto;
 import com.zelusik.eatery.app.dto.member.MemberDeletionSurveyDto;
 import com.zelusik.eatery.app.dto.member.MemberDto;
 import com.zelusik.eatery.app.dto.member.request.MemberUpdateRequest;
@@ -18,7 +19,6 @@ import com.zelusik.eatery.global.exception.member.MemberIdNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -139,15 +139,15 @@ public class MemberService {
     public MemberDto updateMember(Long memberId, MemberUpdateRequest updateRequest) {
         Member member = findEntityById(memberId);
 
-        MultipartFile profileImageFile = updateRequest.getProfileImage();
-        if (profileImageFile == null || profileImageFile.isEmpty()) {
+        ImageDto imageDto = updateRequest.getProfileImage();
+        if (imageDto == null) {
             member.update(
                     updateRequest.getNickname(),
                     updateRequest.getBirthDay(),
                     updateRequest.getGender()
             );
         } else {
-            ProfileImage profileImage = profileImageService.upload(member, profileImageFile);
+            ProfileImage profileImage = profileImageService.upload(member, imageDto);
             member.update(
                     profileImage.getUrl(),
                     profileImage.getThumbnailUrl(),

--- a/src/main/java/com/zelusik/eatery/app/service/ProfileImageService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/ProfileImageService.java
@@ -2,11 +2,12 @@ package com.zelusik.eatery.app.service;
 
 import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.member.ProfileImage;
+import com.zelusik.eatery.app.dto.ImageDto;
+import com.zelusik.eatery.app.dto.file.S3FileDto;
 import com.zelusik.eatery.app.repository.member.ProfileImageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -19,15 +20,16 @@ public class ProfileImageService {
     private static final String DIR_PATH = "member/";
 
     @Transactional
-    public ProfileImage upload(Member member, MultipartFile multipartFile) {
-        S3ImageDto s3ImageDto = fileService.uploadImage(multipartFile, DIR_PATH);
+    public ProfileImage upload(Member member, ImageDto profileImage) {
+        S3FileDto image = fileService.uploadFile(profileImage.getImage(), DIR_PATH);
+        S3FileDto thumbnailImage = fileService.uploadFile(profileImage.getThumbnailImage(), DIR_PATH + "thumbnail/");
         return profileImageRepository.save(ProfileImage.of(
                 member,
-                s3ImageDto.originalName(),
-                s3ImageDto.storedName(),
-                s3ImageDto.url(),
-                s3ImageDto.thumbnailStoredName(),
-                s3ImageDto.thumbnailUrl()
+                image.getOriginalName(),
+                image.getStoredName(),
+                image.getUrl(),
+                thumbnailImage.getStoredName(),
+                thumbnailImage.getUrl()
         ));
     }
 }

--- a/src/main/java/com/zelusik/eatery/app/service/ReviewImageService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/ReviewImageService.java
@@ -3,12 +3,13 @@ package com.zelusik.eatery.app.service;
 import com.zelusik.eatery.app.domain.place.Place;
 import com.zelusik.eatery.app.domain.review.Review;
 import com.zelusik.eatery.app.domain.review.ReviewImage;
+import com.zelusik.eatery.app.dto.ImageDto;
+import com.zelusik.eatery.app.dto.file.S3FileDto;
 import com.zelusik.eatery.app.dto.review.ReviewImageDto;
 import com.zelusik.eatery.app.repository.review.ReviewImageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -25,20 +26,21 @@ public class ReviewImageService {
     /**
      * Review 첨부 파일을 S3 bucket에 업로드한다.
      *
-     * @param review         파일이 첨부될 리뷰
-     * @param multipartFiles 업로드할 파일들
+     * @param review 파일이 첨부될 리뷰
+     * @param images 업로드할 이미지들
      */
     @Transactional
-    public void upload(Review review, List<MultipartFile> multipartFiles) {
-        multipartFiles.forEach(multipartFile -> {
-            S3ImageDto s3ImageDto = fileService.uploadImage(multipartFile, DIR_PATH);
+    public void upload(Review review, List<ImageDto> images) {
+        images.forEach(imageDto -> {
+            S3FileDto image = fileService.uploadFile(imageDto.getImage(), DIR_PATH);
+            S3FileDto thumbnailImage = fileService.uploadFile(imageDto.getThumbnailImage(), DIR_PATH + "thumbnail/");
             review.getReviewImages().add(ReviewImage.of(
                     review,
-                    s3ImageDto.originalName(),
-                    s3ImageDto.storedName(),
-                    s3ImageDto.url(),
-                    s3ImageDto.thumbnailStoredName(),
-                    s3ImageDto.thumbnailUrl()
+                    image.getOriginalName(),
+                    image.getStoredName(),
+                    image.getUrl(),
+                    thumbnailImage.getStoredName(),
+                    thumbnailImage.getUrl()
             ));
         });
         reviewImageRepository.saveAll(review.getReviewImages());

--- a/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/ReviewService.java
@@ -5,6 +5,7 @@ import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.place.Place;
 import com.zelusik.eatery.app.domain.review.Review;
 import com.zelusik.eatery.app.domain.review.ReviewKeyword;
+import com.zelusik.eatery.app.dto.ImageDto;
 import com.zelusik.eatery.app.dto.place.PlaceDto;
 import com.zelusik.eatery.app.dto.place.request.PlaceCreateRequest;
 import com.zelusik.eatery.app.dto.review.ReviewDtoWithMember;
@@ -22,7 +23,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -43,11 +43,11 @@ public class ReviewService {
      *
      * @param writerId      리뷰를 생성하고자 하는 회원의 PK.
      * @param reviewRequest 생성할 리뷰의 정보. 여기에 장소 정보도 포함되어 있다.
-     * @param files         리뷰와 함께 업로드 할 파일 목록
+     * @param images         리뷰와 함께 업로드 할 파일 목록
      * @return 생성된 리뷰 정보가 담긴 dto.
      */
     @Transactional
-    public ReviewDtoWithMemberAndPlace create(Long writerId, ReviewCreateRequest reviewRequest, List<MultipartFile> files) {
+    public ReviewDtoWithMemberAndPlace create(Long writerId, ReviewCreateRequest reviewRequest, List<ImageDto> images) {
         // 장소 조회 or 저장
         PlaceCreateRequest placeCreateRequest = reviewRequest.getPlace();
         Place place = placeService.findOptEntityByKakaoPid(placeCreateRequest.getKakaoPid())
@@ -67,7 +67,7 @@ public class ReviewService {
                     reviewKeywordRepository.save(reviewKeyword);
                 });
 
-        reviewImageService.upload(review, files);
+        reviewImageService.upload(review, images);
 
         // 장소 top 3 keyword 설정
         renewPlaceTop3Keywords(place);

--- a/src/main/java/com/zelusik/eatery/app/service/S3ImageDto.java
+++ b/src/main/java/com/zelusik/eatery/app/service/S3ImageDto.java
@@ -1,12 +1,18 @@
 package com.zelusik.eatery.app.service;
 
-public record S3ImageDto(
-        String originalName,
-        String storedName,
-        String url,
-        String thumbnailStoredName,
-        String thumbnailUrl
-) {
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class S3ImageDto {
+
+    private String originalName;
+    private String storedName;
+    private String url;
+    private String thumbnailStoredName;
+    private String thumbnailUrl;
 
     public static S3ImageDto of(String originalName, String storedName, String url, String thumbnailStoredName, String thumbnailUrl) {
         return new S3ImageDto(originalName, storedName, url, thumbnailStoredName, thumbnailUrl);

--- a/src/test/java/com/zelusik/eatery/app/controller/MemberControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/app/controller/MemberControllerTest.java
@@ -1,7 +1,9 @@
 package com.zelusik.eatery.app.controller;
 
 import com.zelusik.eatery.app.config.SecurityConfig;
+import com.zelusik.eatery.app.constant.member.Gender;
 import com.zelusik.eatery.app.dto.member.request.FavoriteFoodCategoriesUpdateRequest;
+import com.zelusik.eatery.app.dto.member.request.MemberUpdateRequest;
 import com.zelusik.eatery.app.dto.member.request.TermsAgreeRequest;
 import com.zelusik.eatery.app.dto.terms_info.TermsInfoDto;
 import com.zelusik.eatery.app.service.MemberService;
@@ -16,10 +18,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -124,6 +128,34 @@ class MemberControllerTest {
         // when & then
         mvc.perform(
                         get("/api/members")
+                                .with(csrf())
+                                .with(user(UserPrincipal.of(MemberTestUtils.createMemberDtoWithId())))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(memberId));
+    }
+
+    @DisplayName("프로필 이미지를 제외한 수정할 회원 정보가 주어지고, 내 정보를 수정한다.")
+    @Test
+    void givenMemberUpdateInfoWithoutProfileImage_whenUpdatingMyInfo_thenUpdate() throws Exception {
+        // given
+        long memberId = 1L;
+        MemberUpdateRequest memberUpdateInfo = MemberUpdateRequest.of(
+                "update",
+                LocalDate.of(2020, 1, 1),
+                Gender.ETC,
+                null
+        );
+        given(memberService.updateMember(eq(memberId), any(MemberUpdateRequest.class)))
+                .willReturn(MemberTestUtils.createMemberDtoWithId(memberId));
+
+        // when & then
+        // TODO: 프로필 이미지는 어떻게 넣어야 하는지 확인 후 코드 수정 필요
+        mvc.perform(
+                        multipart(HttpMethod.PUT, "/api/members")
+                                .param("nickname", memberUpdateInfo.getNickname())
+                                .param("birthDay", memberUpdateInfo.getBirthDay().toString())
+                                .param("gender", memberUpdateInfo.getGender().toString())
                                 .with(csrf())
                                 .with(user(UserPrincipal.of(MemberTestUtils.createMemberDtoWithId())))
                 )

--- a/src/test/java/com/zelusik/eatery/app/service/ProfileImageServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/app/service/ProfileImageServiceTest.java
@@ -1,0 +1,58 @@
+package com.zelusik.eatery.app.service;
+
+import com.zelusik.eatery.app.domain.member.Member;
+import com.zelusik.eatery.app.domain.member.ProfileImage;
+import com.zelusik.eatery.app.dto.ImageDto;
+import com.zelusik.eatery.app.repository.member.ProfileImageRepository;
+import com.zelusik.eatery.util.MemberTestUtils;
+import com.zelusik.eatery.util.MultipartFileTestUtils;
+import com.zelusik.eatery.util.S3FileTestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("[Service] ProfileImage")
+@ExtendWith(MockitoExtension.class)
+class ProfileImageServiceTest {
+
+    @InjectMocks
+    private ProfileImageService sut;
+
+    @Mock
+    private FileService fileService;
+    @Mock
+    private ProfileImageRepository profileImageRepository;
+
+    @DisplayName("프로필 이미지(원본, 썸네일)이 주어지면, 이미지를 업로드한다.")
+    @Test
+    void givenProfileImages_whenUploading_thenUploadImages() {
+        // given
+        long memberId = 1L;
+        Member member = MemberTestUtils.createMember(memberId);
+        ImageDto imageDto = MultipartFileTestUtils.createMockImageDto();
+        ProfileImage expectedResult = MemberTestUtils.createProfileImage();
+        given(fileService.uploadFile(any(MultipartFile.class), any(String.class)))
+                .willReturn(S3FileTestUtils.createS3FileDto());
+        given(profileImageRepository.save(any(ProfileImage.class))).willReturn(expectedResult);
+
+        // when
+        ProfileImage actualResult = sut.upload(member, imageDto);
+
+        // then
+        verify(fileService, times(2)).uploadFile(any(MultipartFile.class), any(String.class));
+        then(profileImageRepository).should().save(any(ProfileImage.class));
+        assertThat(actualResult).isNotNull();
+        assertThat(actualResult.getId()).isEqualTo(expectedResult.getId());
+    }
+}

--- a/src/test/java/com/zelusik/eatery/app/service/ReviewImageServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/app/service/ReviewImageServiceTest.java
@@ -1,6 +1,7 @@
 package com.zelusik.eatery.app.service;
 
 import com.zelusik.eatery.app.domain.review.Review;
+import com.zelusik.eatery.app.dto.ImageDto;
 import com.zelusik.eatery.app.repository.review.ReviewImageRepository;
 import com.zelusik.eatery.util.MultipartFileTestUtils;
 import com.zelusik.eatery.util.ReviewTestUtils;
@@ -18,6 +19,8 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @DisplayName("[Service] Review File")
 @ExtendWith(MockitoExtension.class)
@@ -35,17 +38,17 @@ class ReviewImageServiceTest {
     @Test
     void givenImageFiles_whenUploading_thenUploadFiles() {
         // given
-        List<MultipartFile> multipartFiles = List.of(MultipartFileTestUtils.createMockMultipartFile());
+        List<ImageDto> images = List.of(MultipartFileTestUtils.createMockImageDto());
         Review review = ReviewTestUtils.createReviewWithId(1L, "1");
-        given(fileService.uploadImage(any(MultipartFile.class), any(String.class)))
-                .willReturn(S3FileTestUtils.createS3ImageDto());
+        given(fileService.uploadFile(any(MultipartFile.class), any(String.class)))
+                .willReturn(S3FileTestUtils.createS3FileDto());
         given(reviewImageRepository.saveAll(any())).willReturn(List.of());
 
         // when
-        sut.upload(review, multipartFiles);
+        sut.upload(review, images);
 
         // then
-        then(fileService).should().uploadImage(any(MultipartFile.class), any(String.class));
+        verify(fileService, times(2)).uploadFile(any(MultipartFile.class), any(String.class));
         then(reviewImageRepository).should().saveAll(any());
     }
 }

--- a/src/test/java/com/zelusik/eatery/app/service/ReviewServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/app/service/ReviewServiceTest.java
@@ -2,9 +2,10 @@ package com.zelusik.eatery.app.service;
 
 import com.zelusik.eatery.app.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.app.domain.member.Member;
-import com.zelusik.eatery.app.domain.review.Review;
 import com.zelusik.eatery.app.domain.place.Place;
+import com.zelusik.eatery.app.domain.review.Review;
 import com.zelusik.eatery.app.domain.review.ReviewKeyword;
+import com.zelusik.eatery.app.dto.ImageDto;
 import com.zelusik.eatery.app.dto.review.ReviewDtoWithMember;
 import com.zelusik.eatery.app.dto.review.ReviewDtoWithMemberAndPlace;
 import com.zelusik.eatery.app.dto.review.request.ReviewCreateRequest;
@@ -73,7 +74,7 @@ class ReviewServiceTest {
         ReviewDtoWithMemberAndPlace actualSavedReview = sut.create(
                 writerId,
                 reviewCreateRequest,
-                List.of(MultipartFileTestUtils.createMockMultipartFile())
+                List.of(MultipartFileTestUtils.createMockImageDto())
         );
 
         // then
@@ -112,7 +113,7 @@ class ReviewServiceTest {
         ReviewDtoWithMemberAndPlace actualSavedReview = sut.create(
                 writerId,
                 reviewCreateRequest,
-                List.of(MultipartFileTestUtils.createMockMultipartFile())
+                List.of(MultipartFileTestUtils.createMockImageDto())
         );
 
         // then

--- a/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
@@ -2,9 +2,10 @@ package com.zelusik.eatery.util;
 
 import com.zelusik.eatery.app.constant.ConstantUtil;
 import com.zelusik.eatery.app.constant.FoodCategory;
-import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.constant.member.Gender;
 import com.zelusik.eatery.app.constant.member.LoginType;
+import com.zelusik.eatery.app.domain.member.Member;
+import com.zelusik.eatery.app.domain.member.ProfileImage;
 import com.zelusik.eatery.app.dto.member.MemberDto;
 
 import java.time.LocalDate;
@@ -72,6 +73,21 @@ public class MemberTestUtils {
                 List.of(FoodCategory.KOREAN),
                 LocalDateTime.now(),
                 LocalDateTime.now(),
+                null
+        );
+    }
+
+    public static ProfileImage createProfileImage() {
+        return ProfileImage.of(
+                10L,
+                createMember(1L),
+                "originalFilename",
+                "storedFilename",
+                "url",
+                "thumbnailStoredFilename",
+                "thumbnailUrl",
+                LocalDateTime.of(2023, 1, 1, 0, 0),
+                LocalDateTime.of(2023, 1, 1, 0, 0),
                 null
         );
     }

--- a/src/test/java/com/zelusik/eatery/util/MultipartFileTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/MultipartFileTestUtils.java
@@ -1,9 +1,17 @@
 package com.zelusik.eatery.util;
 
+import com.zelusik.eatery.app.dto.ImageDto;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 
 public class MultipartFileTestUtils {
+
+    public static ImageDto createMockImageDto() {
+        return ImageDto.of(
+                createMockMultipartFile(),
+                createMockMultipartFile()
+        );
+    }
 
     public static MockMultipartFile createMockMultipartFile() {
         return new MockMultipartFile(

--- a/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/ReviewTestUtils.java
@@ -2,9 +2,10 @@ package com.zelusik.eatery.util;
 
 import com.zelusik.eatery.app.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.app.domain.member.Member;
-import com.zelusik.eatery.app.domain.review.Review;
 import com.zelusik.eatery.app.domain.place.Place;
+import com.zelusik.eatery.app.domain.review.Review;
 import com.zelusik.eatery.app.domain.review.ReviewKeyword;
+import com.zelusik.eatery.app.dto.ImageDto;
 import com.zelusik.eatery.app.dto.review.ReviewDtoWithMember;
 import com.zelusik.eatery.app.dto.review.ReviewDtoWithMemberAndPlace;
 import com.zelusik.eatery.app.dto.review.ReviewImageDto;
@@ -22,7 +23,7 @@ public class ReviewTestUtils {
                 List.of("신선한 재료"),
                 "자동 생성된 내용",
                 "제출한 내용",
-                List.of(MultipartFileTestUtils.createMockMultipartFile())
+                List.of(MultipartFileTestUtils.createMockImageDto())
         );
     }
 


### PR DESCRIPTION
## 🔥 Related Issue
- Close #122

## 🏃‍ Task
- 이미지 파일 업로드 API 스펙 변경
- 리뷰 생성 및 회원정보 수정 시 이미지 생성 로직 변경
  - (기존) 하나의 이미지를 받아 썸네일 이미지를 생성한 후, 원본과 썸네일 이미지를 저장
  - (현재) 두 개의 이미지(원본, 썸네일)를 받은 후 그대로 저장.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
