### PR TITLE
회원 탈퇴 시 약관 동의 정보도 함께 삭제

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/dto/review/request/MemberDeletionSurveyRequest.java
+++ b/src/main/java/com/zelusik/eatery/app/dto/review/request/MemberDeletionSurveyRequest.java
@@ -2,14 +2,23 @@ package com.zelusik.eatery.app.dto.review.request;
 
 import com.zelusik.eatery.app.constant.review.MemberDeletionSurveyType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class MemberDeletionSurveyRequest {
 
     @Schema(description = "회원 탈퇴 설문 응답", example = "HARD_TO_WRITE")
     @NotNull
     private MemberDeletionSurveyType surveyType;
+
+    public static MemberDeletionSurveyRequest of(MemberDeletionSurveyType surveyType) {
+        return new MemberDeletionSurveyRequest(surveyType);
+    }
 }

--- a/src/main/java/com/zelusik/eatery/app/service/MemberService.java
+++ b/src/main/java/com/zelusik/eatery/app/service/MemberService.java
@@ -182,6 +182,7 @@ public class MemberService {
     public MemberDeletionSurveyDto delete(Long memberId, MemberDeletionSurveyType surveyType) {
         Member member = findEntityById(memberId);
         memberRepository.delete(member);
+        termsInfoRepository.delete(member.getTermsInfo());
 
         return MemberDeletionSurveyDto.from(
                 memberDeletionSurveyRepository.save(

--- a/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
@@ -4,8 +4,11 @@ import com.zelusik.eatery.app.constant.ConstantUtil;
 import com.zelusik.eatery.app.constant.FoodCategory;
 import com.zelusik.eatery.app.constant.member.Gender;
 import com.zelusik.eatery.app.constant.member.LoginType;
+import com.zelusik.eatery.app.constant.review.MemberDeletionSurveyType;
 import com.zelusik.eatery.app.domain.member.Member;
+import com.zelusik.eatery.app.domain.member.MemberDeletionSurvey;
 import com.zelusik.eatery.app.domain.member.ProfileImage;
+import com.zelusik.eatery.app.dto.member.MemberDeletionSurveyDto;
 import com.zelusik.eatery.app.dto.member.MemberDto;
 
 import java.time.LocalDate;
@@ -89,6 +92,24 @@ public class MemberTestUtils {
                 LocalDateTime.of(2023, 1, 1, 0, 0),
                 LocalDateTime.of(2023, 1, 1, 0, 0),
                 null
+        );
+    }
+
+    public static MemberDeletionSurveyDto createMemberDeletionSurveyDto(Long memberId, MemberDeletionSurveyType surveyType) {
+        return MemberDeletionSurveyDto.of(
+                10L,
+                memberId,
+                surveyType
+        );
+    }
+
+    public static MemberDeletionSurvey createMemberDeletionSurvey(Member member, MemberDeletionSurveyType surveyType) {
+        return MemberDeletionSurvey.of(
+                10L,
+                member,
+                surveyType,
+                LocalDateTime.of(2023, 1, 1, 0, 0),
+                LocalDateTime.of(2023, 1, 1, 0, 0)
         );
     }
 }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #126

## 🏃‍ Task
- 회원 탈퇴 시 약관 동의 정보도 함께 삭제하도록 로직 추가

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
