### PR TITLE
가게 검색 시 삭제된 리뷰에 있는 사진이 대표 사진으로 조회되는 버그 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/repository/place/PlaceJdbcTemplateRepositoryImpl.java
+++ b/src/main/java/com/zelusik/eatery/app/repository/place/PlaceJdbcTemplateRepositoryImpl.java
@@ -45,9 +45,9 @@ public class PlaceJdbcTemplateRepositoryImpl implements PlaceJdbcTemplateReposit
                 .append("ri3.review_image_id as ri3_review_image_id, ri3.review_id as ri3_review_id, ri3.original_name as ri3_original_name, ri3.stored_name as ri3_stored_name, ri3.url as ri3_url, ri3.thumbnail_stored_name as ri3_thumbnail_stored_name, ri3.thumbnail_url as ri3_thumbnail_url, ri3.created_at as ri3_created_at, ri3.updated_at as ri3_updated_at, ri3.deleted_at as ri3_deleted_at, ")
                 .append("(6371 * acos(cos(radians(:lat)) * cos(radians(lat)) * cos(radians(lng) - radians(:lng)) + sin(radians(:lat)) * sin(radians(lat)))) as distance ")
                 .append("from place p ")
-                .append("left join review_image ri1 on ri1.review_image_id = (select ri.review_image_id from review_image ri join review r on r.review_id = ri.review_id where r.place_id = p.place_id order by r.created_at desc limit 1 offset 0) ")
-                .append("left join review_image ri2 on ri2.review_image_id = (select ri.review_image_id from review_image ri join review r on r.review_id = ri.review_id where r.place_id = p.place_id order by r.created_at desc limit 1 offset 1) ")
-                .append("left join review_image ri3 on ri3.review_image_id = (select ri.review_image_id from review_image ri join review r on r.review_id = ri.review_id where r.place_id = p.place_id order by r.created_at desc limit 1 offset 2) ");
+                .append("left join review_image ri1 on ri1.review_image_id = (select ri.review_image_id from review_image ri join review r on r.review_id = ri.review_id and ri.deleted_at is null where r.place_id = p.place_id order by r.created_at desc limit 1 offset 0) ")
+                .append("left join review_image ri2 on ri2.review_image_id = (select ri.review_image_id from review_image ri join review r on r.review_id = ri.review_id and ri.deleted_at is null where r.place_id = p.place_id order by r.created_at desc limit 1 offset 1) ")
+                .append("left join review_image ri3 on ri3.review_image_id = (select ri.review_image_id from review_image ri join review r on r.review_id = ri.review_id and ri.deleted_at is null where r.place_id = p.place_id order by r.created_at desc limit 1 offset 2) ");
 
         if (daysOfWeek != null && !daysOfWeek.isEmpty()) {
             sql.append("inner join opening_hours oh ")
@@ -124,7 +124,7 @@ public class PlaceJdbcTemplateRepositoryImpl implements PlaceJdbcTemplateReposit
                        ri1.created_at            as ri1_created_at,
                        ri1.updated_at            as ri1_updated_at,
                        ri1.deleted_at            as ri1_deleted_at,
-                       ri2.review_image_id        as ri2_review_image_id,
+                       ri2.review_image_id       as ri2_review_image_id,
                        ri2.review_id             as ri2_review_id,
                        ri2.original_name         as ri2_original_name,
                        ri2.stored_name           as ri2_stored_name,


### PR DESCRIPTION
## 🔥 Related Issue
- Close #128

## 🏃‍ Task
- 가게 검색 시 삭제된 리뷰에 있는 사진이 대표 사진으로 조회되는 버그 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
