### PR TITLE
fix: #131 회원 탈퇴 중 이용약관(TermsInfo) 삭제가 되지 않아 exception이 발생하는 버그 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/app/domain/member/Member.java
+++ b/src/main/java/com/zelusik/eatery/app/domain/member/Member.java
@@ -27,7 +27,7 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id", nullable = false)
     private Long id;
 
-    @Setter
+    @Setter(AccessLevel.PRIVATE)
     @JoinColumn(name = "terms_info_id")
     @OneToOne(fetch = FetchType.LAZY)
     private TermsInfo termsInfo;
@@ -94,6 +94,10 @@ public class Member extends BaseTimeEntity {
                 .build();
     }
 
+    public void addTermsInfo(TermsInfo termsInfo) {
+        this.setTermsInfo(termsInfo);
+    }
+
     public void update(String profileImageUrl, String profileThumbnailImageUrl, String nickname, LocalDate birthDay, Gender gender) {
         this.setProfileImageUrl(profileImageUrl);
         this.setProfileThumbnailImageUrl(profileThumbnailImageUrl);
@@ -110,6 +114,10 @@ public class Member extends BaseTimeEntity {
 
     public void rejoin() {
         this.setDeletedAt(null);
+    }
+
+    public void removeTermsInfo() {
+        this.setTermsInfo(null);
     }
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/src/test/java/com/zelusik/eatery/app/service/MemberServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/app/service/MemberServiceTest.java
@@ -230,10 +230,11 @@ class MemberServiceTest {
         // given
         long memberId = 1L;
         MemberDeletionSurveyType surveyType = MemberDeletionSurveyType.NOT_TRUST;
-        Member findMember = createMember(memberId);
+        Member findMember = createMemberWithTermsInfo(memberId);
+        TermsInfo memberTermsInfo = findMember.getTermsInfo();
         given(memberRepository.findByIdAndDeletedAtNull(memberId)).willReturn(Optional.of(findMember));
+        willDoNothing().given(termsInfoRepository).delete(memberTermsInfo);
         willDoNothing().given(memberRepository).delete(findMember);
-        willDoNothing().given(termsInfoRepository).delete(findMember.getTermsInfo());
         given(memberDeletionSurveyRepository.save(any(MemberDeletionSurvey.class)))
                 .willReturn(MemberTestUtils.createMemberDeletionSurvey(findMember, surveyType));
 
@@ -242,9 +243,10 @@ class MemberServiceTest {
 
         // then
         then(memberRepository).should().findByIdAndDeletedAtNull(memberId);
+        then(termsInfoRepository).should().delete(memberTermsInfo);
         then(memberRepository).should().delete(findMember);
-        then(termsInfoRepository).should().delete(findMember.getTermsInfo());
         then(memberDeletionSurveyRepository).should().save(any(MemberDeletionSurvey.class));
+        assertThat(findMember.getTermsInfo()).isNull(); // 회원의 약관동의 정보가 null이 된다.
         assertThat(surveyResult.getSurveyType()).isEqualTo(surveyType);
     }
 }

--- a/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
+++ b/src/test/java/com/zelusik/eatery/util/MemberTestUtils.java
@@ -8,6 +8,7 @@ import com.zelusik.eatery.app.constant.review.MemberDeletionSurveyType;
 import com.zelusik.eatery.app.domain.member.Member;
 import com.zelusik.eatery.app.domain.member.MemberDeletionSurvey;
 import com.zelusik.eatery.app.domain.member.ProfileImage;
+import com.zelusik.eatery.app.domain.member.TermsInfo;
 import com.zelusik.eatery.app.dto.member.MemberDeletionSurveyDto;
 import com.zelusik.eatery.app.dto.member.MemberDto;
 
@@ -64,6 +65,35 @@ public class MemberTestUtils {
         return Member.of(
                 memberId,
                 null,
+                ConstantUtil.defaultProfileImageUrl,
+                ConstantUtil.defaultProfileThumbnailImageUrl,
+                SOCIAL_UID,
+                LoginType.KAKAO,
+                EMAIL,
+                NICKNAME,
+                LocalDate.of(1998, 1, 5),
+                AGE_RANGE,
+                GENDER,
+                List.of(FoodCategory.KOREAN),
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+    public static Member createMemberWithTermsInfo(Long memberId) {
+        return Member.of(
+                memberId,
+                TermsInfo.of(
+                        1L,
+                        true,
+                        true, LocalDateTime.of(2023, 1, 1, 0, 0),
+                        true, LocalDateTime.of(2023, 1, 1, 0, 0),
+                        true, LocalDateTime.of(2023, 1, 1, 0, 0),
+                        true, LocalDateTime.of(2023, 1, 1, 0, 0),
+                        LocalDateTime.of(2023, 1, 1, 0, 0),
+                        LocalDateTime.of(2023, 1, 1, 0, 0)
+                ),
                 ConstantUtil.defaultProfileImageUrl,
                 ConstantUtil.defaultProfileThumbnailImageUrl,
                 SOCIAL_UID,


### PR DESCRIPTION
## 🔥 Related Issue
- Close #131

## 🏃‍ Task
- 회원 탈퇴 중 이용약관(TermsInfo) 삭제가 되지 않아 exception이 발생하는 버그 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
