### PR TITLE
저장한 장소 목록 조회 API에 필터링 조건으로 filtering keyword 추가 - 기존 음식 카테고리를 `first_category`와 `second_category`로 분리

### DIFF
--- a/src/main/java/com/zelusik/eatery/constant/place/FilteringType.java
+++ b/src/main/java/com/zelusik/eatery/constant/place/FilteringType.java
@@ -4,11 +4,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "<p>저장된 장소에 대한 filtering keyword의 유형." +
         "<ul>" +
-        "<li><code>CATEGORY</code>: 음식 카테고리 (second category)</li>" +
+        "<li><code>SECOND_CATEGORY</code>: 음식 카테고리 (second category)</li>" +
         "<li><code>TOP_3_KEYWORDS</code>: 장소의 top 3 keyword</li>" +
         "<li><code>ADDRESS</code>: 장소의 주소 (ex. 영통구, 연남동 등)</li>" +
         "</ul>",
         example = "ADDRESS")
 public enum FilteringType {
-    CATEGORY, TOP_3_KEYWORDS, ADDRESS, NONE
+    FIRST_CATEGORY,
+    SECOND_CATEGORY,
+    TOP_3_KEYWORDS,
+    ADDRESS,
+    NONE,
 }

--- a/src/main/java/com/zelusik/eatery/controller/PlaceController.java
+++ b/src/main/java/com/zelusik/eatery/controller/PlaceController.java
@@ -150,7 +150,8 @@ public class PlaceController {
             @Parameter(
                     description = "<p>Filtering 조건 유형. 값은 다음과 같습니다." +
                             "<ul>" +
-                            "<li><code>CATEGORY</code>: 음식 카테고리 (second category)</li>" +
+                            "<li><code>FIRST_CATEGORY</code>: 음식 카테고리(first category). 한식, 일식 등)</li>" +
+                            "<li><code>SECOND_CATEGORY</code>: 음식 카테고리(second category) 햄버거, 피자, 국밥 등</li>" +
                             "<li><code>TOP_3_KEYWORDS</code>: 장소의 top 3 keyword</li>" +
                             "<li><code>ADDRESS</code>: 장소의 주소 (ex. 영통구, 연남동 등)</li>" +
                             "</ul>",

--- a/src/main/java/com/zelusik/eatery/controller/PlaceController.java
+++ b/src/main/java/com/zelusik/eatery/controller/PlaceController.java
@@ -172,14 +172,6 @@ public class PlaceController {
         if (type == FilteringType.TOP_3_KEYWORDS) {
             keyword = ReviewKeywordValue.valueOfDescription(keyword).toString();
         }
-
-        System.out.println("userPrincipal.getMemberId() = " + userPrincipal.getMemberId());
-        System.out.println("userPrincipal.getMemberId().getClass() = " + userPrincipal.getMemberId().getClass());
-        System.out.println("type = " + type);
-        System.out.println("type.getClass() = " + type.getClass());
-        System.out.println("keyword = " + keyword);
-        System.out.println("keyword.getClass() = " + keyword.getClass());
-        
         Slice<MarkedPlaceResponse> markedPlaces = placeService.findMarkedDtos(
                 userPrincipal.getMemberId(), type, keyword, PageRequest.of(page, size)
         ).map(MarkedPlaceResponse::from);

--- a/src/test/java/com/zelusik/eatery/service/PlaceServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/service/PlaceServiceTest.java
@@ -303,7 +303,7 @@ class PlaceServiceTest {
         // given
         long memberId = 1L;
         long placeId = 2L;
-        FilteringType filteringType = FilteringType.CATEGORY;
+        FilteringType filteringType = FilteringType.SECOND_CATEGORY;
         String filteringKeyword = "고기,육류";
         Pageable pageable = Pageable.ofSize(30);
         SliceImpl<PlaceDtoWithImages> expectedResult = new SliceImpl<>(List.of(PlaceTestUtils.createPlaceDtoWithImagesAndOpeningHours(placeId)));


### PR DESCRIPTION
## 🔥 Related Issue
- Close #159

## 🏃‍ Task
- NPE를 발생시키는 임시 디버깅용 코드 제거
- Filtering type에서 기존 음식 카테고리를 `first_category`와 `second_category`로 분리

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
