### PR TITLE
저장한 장소 목록 조회 API에 필터링 조건으로 filtering keyword 추가 - 버그 수정 및 제약조건 추가

### DIFF
--- a/src/main/java/com/zelusik/eatery/constant/ConstantUtil.java
+++ b/src/main/java/com/zelusik/eatery/constant/ConstantUtil.java
@@ -4,4 +4,6 @@ public class ConstantUtil {
 
     public static final String defaultProfileImageUrl = "https://eatery-s3-bucket.s3.ap-northeast-2.amazonaws.com/member/default-profile-image";
     public static final String defaultProfileThumbnailImageUrl = "https://eatery-s3-bucket.s3.ap-northeast-2.amazonaws.com/member/default-profile-image";
+
+    public static final int MAX_NUM_OF_FILTERING_KEYWORDS = 8;
 }

--- a/src/main/java/com/zelusik/eatery/constant/place/FilteringType.java
+++ b/src/main/java/com/zelusik/eatery/constant/place/FilteringType.java
@@ -4,7 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "<p>저장된 장소에 대한 filtering keyword의 유형." +
         "<ul>" +
-        "<li><code>SECOND_CATEGORY</code>: 음식 카테고리 (second category)</li>" +
+        "<li><code>FIRST_CATEGORY</code>: 음식 카테고리(first category). 한식, 일식 등)</li>" +
+        "<li><code>SECOND_CATEGORY</code>: 음식 카테고리(second category) 햄버거, 피자, 국밥 등</li>" +
         "<li><code>TOP_3_KEYWORDS</code>: 장소의 top 3 keyword</li>" +
         "<li><code>ADDRESS</code>: 장소의 주소 (ex. 영통구, 연남동 등)</li>" +
         "</ul>",

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
@@ -266,7 +266,7 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
                 .addValue("member_id", memberId)
                 .addValue("min_count", minCount);
 
-        return template.query(query, params, placeFilteringKeywordRowMapper(FilteringType.SECOND_CATEGORY));
+        return template.query(query, params, placeFilteringKeywordRowMapper(FilteringType.FIRST_CATEGORY));
     }
 
     /**

--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
@@ -29,6 +29,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import static com.zelusik.eatery.constant.ConstantUtil.MAX_NUM_OF_FILTERING_KEYWORDS;
+
 public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
 
     private final NamedParameterJdbcTemplate template;
@@ -222,7 +224,8 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
 
         return filteringKeywords.stream()
                 .sorted(Comparator.comparing(PlaceFilteringKeywordDto::getCount).reversed())
-                .toList();
+                .toList()
+                .subList(0, MAX_NUM_OF_FILTERING_KEYWORDS);
     }
 
     /**


### PR DESCRIPTION
## 🔥 Related Issue
- Close #159 

## 🏃‍ Task
- 장소의 `first_category`에 대한 keyword type이 `SECOND_CATEGORY`로 오는 버그 수정
- Filtering keyword는 최대 8개까지만 반환하도록 제약조건 로직 추가

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
