### PR TITLE
Filtering keyword가 8개 미만일 경우 `IndexOutOfBounds` 예외가 발생하는 버그 수정

### DIFF
--- a/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/place/PlaceRepositoryJCustomImpl.java
@@ -221,11 +221,11 @@ public class PlaceRepositoryJCustomImpl implements PlaceRepositoryJCustom {
         filteringKeywords.addAll(getSecondCategoryFilteringKeywords(memberId, minCount));
         filteringKeywords.addAll(getAddressFilteringKeywords(memberId, minCount));
         filteringKeywords.addAll(getTop3KeywordFilteringKeywords(memberId, minCount));
+        filteringKeywords.sort(Comparator.comparing(PlaceFilteringKeywordDto::getCount));
 
-        return filteringKeywords.stream()
-                .sorted(Comparator.comparing(PlaceFilteringKeywordDto::getCount).reversed())
-                .toList()
-                .subList(0, MAX_NUM_OF_FILTERING_KEYWORDS);
+        return filteringKeywords.size() < MAX_NUM_OF_FILTERING_KEYWORDS
+                ? filteringKeywords
+                : filteringKeywords.subList(0, MAX_NUM_OF_FILTERING_KEYWORDS);
     }
 
     /**


### PR DESCRIPTION
## 🔥 Related Issue
- Close #159

## 🏃‍ Task
- Filtering keyword가 8개 미만일 경우 `IndexOutOfBounds` 예외가 발생하는 버그 수정

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
