### PR TITLE
약속장소 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,10 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    // JSON and Gson for parse String in format JSON
+    implementation 'org.json:json:20230227'
+    implementation 'com.google.code.gson:gson:2.10.1'
+
     // JSR-305 (https://simple-ing.tistory.com/48)
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 }

--- a/src/main/java/com/zelusik/eatery/config/GsonConfig.java
+++ b/src/main/java/com/zelusik/eatery/config/GsonConfig.java
@@ -1,0 +1,14 @@
+package com.zelusik.eatery.config;
+
+import com.google.gson.Gson;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GsonConfig {
+
+    @Bean
+    public Gson gson() {
+        return new Gson();
+    }
+}

--- a/src/main/java/com/zelusik/eatery/config/RestTemplateConfig.java
+++ b/src/main/java/com/zelusik/eatery/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.zelusik.eatery.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/zelusik/eatery/constant/ConstantUtil.java
+++ b/src/main/java/com/zelusik/eatery/constant/ConstantUtil.java
@@ -1,9 +1,26 @@
 package com.zelusik.eatery.constant;
 
+import com.zelusik.eatery.controller.MeetingPlaceController;
+import com.zelusik.eatery.dto.apple.AppleOAuthUserResponse;
+import com.zelusik.eatery.dto.kakao.KakaoOAuthUserResponse;
+import com.zelusik.eatery.repository.place.PlaceRepositoryJCustomImpl;
+
 public class ConstantUtil {
 
+    /**
+     * @see KakaoOAuthUserResponse
+     * @see AppleOAuthUserResponse
+     */
     public static final String defaultProfileImageUrl = "https://eatery-s3-bucket.s3.ap-northeast-2.amazonaws.com/member/default-profile-image";
     public static final String defaultProfileThumbnailImageUrl = "https://eatery-s3-bucket.s3.ap-northeast-2.amazonaws.com/member/default-profile-image";
 
+    /**
+     * @see PlaceRepositoryJCustomImpl
+     */
     public static final int MAX_NUM_OF_FILTERING_KEYWORDS = 8;
+
+    /**
+     * @see MeetingPlaceController
+     */
+    public static final int PAGE_SIZE_OF_SEARCHING_MEETING_PLACES = 15;
 }

--- a/src/main/java/com/zelusik/eatery/controller/AuthController.java
+++ b/src/main/java/com/zelusik/eatery/controller/AuthController.java
@@ -1,8 +1,8 @@
 package com.zelusik.eatery.controller;
 
 import com.zelusik.eatery.constant.member.LoginType;
-import com.zelusik.eatery.dto.auth.AppleOAuthUserInfo;
-import com.zelusik.eatery.dto.auth.KakaoOAuthUserInfo;
+import com.zelusik.eatery.dto.apple.AppleOAuthUserResponse;
+import com.zelusik.eatery.dto.kakao.KakaoOAuthUserResponse;
 import com.zelusik.eatery.dto.auth.request.AppleLoginRequest;
 import com.zelusik.eatery.dto.auth.request.KakaoLoginRequest;
 import com.zelusik.eatery.dto.auth.request.TokenRefreshRequest;
@@ -54,7 +54,7 @@ public class AuthController {
     })
     @PostMapping("/login/kakao")
     public LoginResponse kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
-        KakaoOAuthUserInfo userInfo = kakaoService.getUserInfo(request.getKakaoAccessToken());
+        KakaoOAuthUserResponse userInfo = kakaoService.getUserInfo(request.getKakaoAccessToken());
 
         MemberDto memberDto = memberService.findOptionalDtoBySocialUidWithDeleted(userInfo.getSocialUid())
                 .orElseGet(() -> memberService.save(userInfo.toMemberDto()));
@@ -83,7 +83,7 @@ public class AuthController {
     })
     @PostMapping("/login/apple")
     public LoginResponse appleLogin(@Valid @RequestBody AppleLoginRequest request) {
-        AppleOAuthUserInfo userInfo = appleOAuthService.getUserInfo(request.getIdentityToken());
+        AppleOAuthUserResponse userInfo = appleOAuthService.getUserInfo(request.getIdentityToken());
 
         MemberDto memberDto = memberService.findOptionalDtoBySocialUidWithDeleted(userInfo.getSub())
                 .orElseGet(() -> memberService.save(userInfo.toMemberDto(request.getName())));

--- a/src/main/java/com/zelusik/eatery/controller/AuthController.java
+++ b/src/main/java/com/zelusik/eatery/controller/AuthController.java
@@ -13,7 +13,7 @@ import com.zelusik.eatery.dto.member.MemberDto;
 import com.zelusik.eatery.dto.member.response.LoggedInMemberResponse;
 import com.zelusik.eatery.service.AppleOAuthService;
 import com.zelusik.eatery.service.JwtTokenService;
-import com.zelusik.eatery.service.KakaoOAuthService;
+import com.zelusik.eatery.service.KakaoService;
 import com.zelusik.eatery.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -35,7 +35,7 @@ import javax.validation.constraints.NotBlank;
 @RestController
 public class AuthController {
 
-    private final KakaoOAuthService kakaoOAuthService;
+    private final KakaoService kakaoService;
     private final AppleOAuthService appleOAuthService;
     private final MemberService memberService;
     private final JwtTokenService jwtTokenService;
@@ -54,7 +54,7 @@ public class AuthController {
     })
     @PostMapping("/login/kakao")
     public LoginResponse kakaoLogin(@Valid @RequestBody KakaoLoginRequest request) {
-        KakaoOAuthUserInfo userInfo = kakaoOAuthService.getUserInfo(request.getKakaoAccessToken());
+        KakaoOAuthUserInfo userInfo = kakaoService.getUserInfo(request.getKakaoAccessToken());
 
         MemberDto memberDto = memberService.findOptionalDtoBySocialUidWithDeleted(userInfo.getSocialUid())
                 .orElseGet(() -> memberService.save(userInfo.toMemberDto()));

--- a/src/main/java/com/zelusik/eatery/controller/MeetingPlaceController.java
+++ b/src/main/java/com/zelusik/eatery/controller/MeetingPlaceController.java
@@ -1,0 +1,85 @@
+package com.zelusik.eatery.controller;
+
+import com.zelusik.eatery.dto.SliceResponse;
+import com.zelusik.eatery.dto.place.response.MeetingPlaceResponse;
+import com.zelusik.eatery.service.KakaoService;
+import com.zelusik.eatery.service.LocationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.zelusik.eatery.constant.ConstantUtil.PAGE_SIZE_OF_SEARCHING_MEETING_PLACES;
+
+@Tag(name = "약속 장소 관련 API")
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/api/meeting-places")
+@RestController
+public class MeetingPlaceController {
+
+    private final LocationService locationService;
+    private final KakaoService kakaoService;
+
+    @Operation(
+            summary = "키워드로 약속 장소 검색하기",
+            description = "<p>키워드로 매칭된 장소 검색 결과를 제공합니다." +
+                    "<p>검색 대상은 행정구역(시/도, 시/군/구, 읍/면/동/구), 지하철역, 관광명소와 학교입니다." +
+                    "<p>한 페이지에 제공되는 장소의 개수는 30개 미만입니다.",
+            security = @SecurityRequirement(name = "access-token")
+    )
+    @GetMapping
+    public SliceResponse<MeetingPlaceResponse> searchMeetingPlaces(
+            @Parameter(
+                    description = "검색 키워드",
+                    example = "광교"
+            ) @RequestParam @NotBlank String keyword,
+            @Parameter(
+                    description = "페이지 번호(0부터 시작합니다).",
+                    example = "0"
+            ) @RequestParam(required = false, defaultValue = "0") int page
+    ) {
+        Page<MeetingPlaceResponse> locations =
+                locationService.searchDtosByKeyword(keyword, PageRequest.of(page, PAGE_SIZE_OF_SEARCHING_MEETING_PLACES))
+                        .map(MeetingPlaceResponse::from);
+        if (locations.getNumberOfElements() >= PAGE_SIZE_OF_SEARCHING_MEETING_PLACES) {
+            return new SliceResponse<MeetingPlaceResponse>().from(locations);
+        }
+
+        int pageForKakaoSearching;
+        if (locations.hasContent()) {
+            pageForKakaoSearching = locations.getTotalPages() - locations.getNumber() - 1;
+        } else {
+            pageForKakaoSearching = page;
+        }
+        Slice<MeetingPlaceResponse> kakaoPlaces =
+                kakaoService.searchKakaoPlacesByKeyword(keyword, PageRequest.of(pageForKakaoSearching, PAGE_SIZE_OF_SEARCHING_MEETING_PLACES))
+                        .map(MeetingPlaceResponse::from);
+
+        List<MeetingPlaceResponse> content = Stream.concat(
+                locations.getContent().stream(),
+                kakaoPlaces.getContent().stream()
+        ).toList();
+
+        Slice<MeetingPlaceResponse> res = new SliceImpl<>(
+                content,
+                PageRequest.of(page, locations.getNumberOfElements() + kakaoPlaces.getNumberOfElements()),
+                kakaoPlaces.hasNext()
+        );
+        return new SliceResponse<MeetingPlaceResponse>().from(res);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/domain/Location.java
+++ b/src/main/java/com/zelusik/eatery/domain/Location.java
@@ -1,0 +1,54 @@
+package com.zelusik.eatery.domain;
+
+import com.zelusik.eatery.domain.place.Point;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(indexes = {
+        @Index(columnList = "sido"),
+        @Index(columnList = "sgg"),
+        @Index(columnList = "emdg")
+})
+@Entity
+public class Location {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "location_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String sido;
+
+    private String sgg;
+
+    private String emdg;
+
+    @Embedded
+    private Point point;
+
+    public static Location of(Long id, String sido, String sgg, String emdg, Point point) {
+        return Location.builder()
+                .id(id)
+                .sido(sido)
+                .sgg(sgg)
+                .emdg(emdg)
+                .point(point)
+                .build();
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Location(Long id, String sido, String sgg, String emdg, Point point) {
+        this.id = id;
+        this.sido = sido;
+        this.sgg = sgg;
+        this.emdg = emdg;
+        this.point = point;
+    }
+}

--- a/src/main/java/com/zelusik/eatery/domain/Location.java
+++ b/src/main/java/com/zelusik/eatery/domain/Location.java
@@ -33,6 +33,10 @@ public class Location {
     @Embedded
     private Point point;
 
+    public static Location of(String sido, String sgg, String emdg, Point point) {
+        return of(null, sido, sgg, emdg, point);
+    }
+
     public static Location of(Long id, String sido, String sgg, String emdg, Point point) {
         return Location.builder()
                 .id(id)

--- a/src/main/java/com/zelusik/eatery/dto/apple/AppleOAuthPublicKey.java
+++ b/src/main/java/com/zelusik/eatery/dto/apple/AppleOAuthPublicKey.java
@@ -1,4 +1,4 @@
-package com.zelusik.eatery.dto.auth;
+package com.zelusik.eatery.dto.apple;
 
 import com.zelusik.eatery.exception.auth.TokenValidateException;
 import lombok.AccessLevel;

--- a/src/main/java/com/zelusik/eatery/dto/apple/AppleOAuthUserResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/apple/AppleOAuthUserResponse.java
@@ -1,4 +1,4 @@
-package com.zelusik.eatery.dto.auth;
+package com.zelusik.eatery.dto.apple;
 
 import com.zelusik.eatery.constant.ConstantUtil;
 import com.zelusik.eatery.constant.member.Gender;
@@ -12,15 +12,15 @@ import lombok.Getter;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class AppleOAuthUserInfo {
+public class AppleOAuthUserResponse {
 
     private String sub;
     private String email;
     private Boolean emailVerified;
     private Boolean isPrivateEmail;
 
-    public static AppleOAuthUserInfo from(Claims claims) {
-        return new AppleOAuthUserInfo(
+    public static AppleOAuthUserResponse from(Claims claims) {
+        return new AppleOAuthUserResponse(
                 claims.getSubject(),
                 claims.get("email", String.class),
                 Boolean.valueOf(claims.get("email_verified", String.class)),

--- a/src/main/java/com/zelusik/eatery/dto/kakao/KakaoOAuthUserResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/kakao/KakaoOAuthUserResponse.java
@@ -1,4 +1,4 @@
-package com.zelusik.eatery.dto.auth;
+package com.zelusik.eatery.dto.kakao;
 
 import com.zelusik.eatery.constant.ConstantUtil;
 import com.zelusik.eatery.constant.member.Gender;
@@ -17,7 +17,7 @@ import java.util.Map;
 @SuppressWarnings("unchecked")  // TODO: Map -> Object 변환 로직이 있어서 generic type casting 문제를 무시한다. 더 좋은 방법이 있다면 고려할 수 있음.
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class KakaoOAuthUserInfo {
+public class KakaoOAuthUserResponse {
 
     private String id;
     private LocalDateTime connectedAt;
@@ -87,8 +87,8 @@ public class KakaoOAuthUserInfo {
         }
     }
 
-    public static KakaoOAuthUserInfo from(Map<String, Object> attributes) {
-        return new KakaoOAuthUserInfo(
+    public static KakaoOAuthUserResponse from(Map<String, Object> attributes) {
+        return new KakaoOAuthUserResponse(
                 String.valueOf(attributes.get("id")),
                 ZonedDateTime.parse(
                         String.valueOf(attributes.get("connected_at")),

--- a/src/main/java/com/zelusik/eatery/dto/kakao/KakaoPlaceResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/kakao/KakaoPlaceResponse.java
@@ -1,0 +1,47 @@
+package com.zelusik.eatery.dto.kakao;
+
+import com.zelusik.eatery.constant.place.KakaoCategoryGroupCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class KakaoPlaceResponse {
+
+    private String placeName;
+    private Integer distance;
+    private String placeUrl;
+    private String categoryName;
+    private String addressName;
+    private String roadAddressName;
+    private String id;
+    private String phone;
+    private KakaoCategoryGroupCode categoryGroupCode;
+    private String x;
+    private String y;
+
+    public static KakaoPlaceResponse of(String placeName, Integer distance, String placeUrl, String categoryName, String addressName, String roadAddressName, String id, String phone, KakaoCategoryGroupCode categoryGroupCode, String x, String y) {
+        return new KakaoPlaceResponse(placeName, distance, placeUrl, categoryName, addressName, roadAddressName, id, phone, categoryGroupCode, x, y);
+    }
+
+    public static KakaoPlaceResponse from(Map<String, Object> attributes) {
+        String distance = String.valueOf(attributes.get("distance"));
+
+        return new KakaoPlaceResponse(
+                String.valueOf(attributes.get("place_name")),
+                distance.isEmpty() ? null : Integer.valueOf(distance),
+                String.valueOf(attributes.get("place_url")),
+                String.valueOf(attributes.get("category_name")),
+                String.valueOf(attributes.get("address_name")),
+                String.valueOf(attributes.get("road_address_name")),
+                String.valueOf(attributes.get("id")),
+                String.valueOf(attributes.get("phone")),
+                KakaoCategoryGroupCode.valueOf(String.valueOf(attributes.get("category_group_code"))),
+                String.valueOf(attributes.get("x")),
+                String.valueOf(attributes.get("y"))
+        );
+    }
+}

--- a/src/main/java/com/zelusik/eatery/dto/location/LocationDto.java
+++ b/src/main/java/com/zelusik/eatery/dto/location/LocationDto.java
@@ -1,0 +1,36 @@
+package com.zelusik.eatery.dto.location;
+
+import com.zelusik.eatery.domain.Location;
+import com.zelusik.eatery.domain.place.Point;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class LocationDto {
+
+    private Long id;
+    private String sido;
+    private String sgg;
+    private String emdg;
+    private Point point;
+
+    public static LocationDto of(String sido, String sgg, String emdg, Point point) {
+        return of(null, sido, sgg, emdg, point);
+    }
+
+    public static LocationDto of(Long id, String sido, String sgg, String emdg, Point point) {
+        return new LocationDto(id, sido, sgg, emdg, point);
+    }
+
+    public static LocationDto from(Location entity) {
+        return of(
+                entity.getId(),
+                entity.getSido(),
+                entity.getSgg(),
+                entity.getEmdg(),
+                entity.getPoint()
+        );
+    }
+}

--- a/src/main/java/com/zelusik/eatery/dto/place/PlaceScrapingInfo.java
+++ b/src/main/java/com/zelusik/eatery/dto/place/PlaceScrapingInfo.java
@@ -1,5 +1,6 @@
 package com.zelusik.eatery.dto.place;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,8 +11,13 @@ import java.util.Map;
 @Getter
 public class PlaceScrapingInfo {
 
+    @SerializedName("opening_hours")
     private String openingHours;
+
+    @SerializedName("closing_hours")
     private String closingHours;
+
+    @SerializedName("homepage_url")
     private String homepageUrl;
 
     public static PlaceScrapingInfo of(String openingHours, String closingHours, String homepageUrl) {

--- a/src/main/java/com/zelusik/eatery/dto/place/response/MeetingPlaceResponse.java
+++ b/src/main/java/com/zelusik/eatery/dto/place/response/MeetingPlaceResponse.java
@@ -1,0 +1,66 @@
+package com.zelusik.eatery.dto.place.response;
+
+import com.zelusik.eatery.domain.place.Point;
+import com.zelusik.eatery.dto.kakao.KakaoPlaceResponse;
+import com.zelusik.eatery.dto.location.LocationDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class MeetingPlaceResponse {
+
+    @Schema(description = "장소의 이름", example = "홍대입구역 2호선")
+    private String name;
+
+    @Schema(description = "장소가 위치한 시/도", example = "서울")
+    private String sido;
+
+    @Schema(description = "장소가 위치한 시/군/구", example = "마포구")
+    private String sgg;
+
+    @Schema(description = "장소가 위치한 읍/면/동", example = "동교동")
+    private String emd;
+
+    @Schema(description = "좌표")
+    private Point point;
+
+    public static MeetingPlaceResponse from(LocationDto dto) {
+        String name = dto.getSido();
+        if (dto.getSgg() != null) {
+            name = dto.getSgg();
+        }
+        if (dto.getEmdg() != null) {
+            name = dto.getEmdg();
+        }
+        return new MeetingPlaceResponse(
+                name,
+                dto.getSido(),
+                dto.getSgg(),
+                dto.getEmdg(),
+                dto.getPoint()
+        );
+    }
+
+    public static MeetingPlaceResponse from(KakaoPlaceResponse response) {
+        String address = response.getAddressName();
+
+        int sidoIdx = address.indexOf(" ");
+        int sggIdx = address.indexOf(" ", sidoIdx + 1);
+        int emdIdx = address.indexOf(" ", sggIdx + 1);
+
+        String sido = sidoIdx != -1 ? address.substring(0, sidoIdx) : null;
+        String sgg = sggIdx != -1 ? address.substring(sidoIdx + 1, sggIdx) : null;
+        String emd = emdIdx != -1 ? address.substring(sggIdx + 1, emdIdx) : null;
+
+        return new MeetingPlaceResponse(
+                response.getPlaceName(),
+                sido,
+                sgg,
+                emd,
+                new Point(response.getY(), response.getX())
+        );
+    }
+}

--- a/src/main/java/com/zelusik/eatery/repository/location/LocationRepository.java
+++ b/src/main/java/com/zelusik/eatery/repository/location/LocationRepository.java
@@ -1,0 +1,9 @@
+package com.zelusik.eatery.repository.location;
+
+import com.zelusik.eatery.domain.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LocationRepository extends
+        JpaRepository<Location, Long>,
+        LocationRepositoryQCustom {
+}

--- a/src/main/java/com/zelusik/eatery/repository/location/LocationRepositoryQCustom.java
+++ b/src/main/java/com/zelusik/eatery/repository/location/LocationRepositoryQCustom.java
@@ -1,0 +1,17 @@
+package com.zelusik.eatery.repository.location;
+
+import com.zelusik.eatery.dto.location.LocationDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface LocationRepositoryQCustom {
+
+    /**
+     * sido, sgg, emdg에 <code>keyword</code>가 포함된 location들을 조회한다.
+     *
+     * @param keyword  검색 키워드
+     * @param pageable paging 정보
+     * @return 조회된 location dtos
+     */
+    Page<LocationDto> searchDtosByKeyword(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/zelusik/eatery/repository/location/LocationRepositoryQCustomImpl.java
+++ b/src/main/java/com/zelusik/eatery/repository/location/LocationRepositoryQCustomImpl.java
@@ -1,0 +1,43 @@
+package com.zelusik.eatery.repository.location;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zelusik.eatery.domain.Location;
+import com.zelusik.eatery.dto.location.LocationDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.zelusik.eatery.domain.QLocation.location;
+
+@RequiredArgsConstructor
+public class LocationRepositoryQCustomImpl implements LocationRepositoryQCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<LocationDto> searchDtosByKeyword(String keyword, Pageable pageable) {
+        List<Location> fetchResult = queryFactory.selectFrom(location)
+                .where(location.sido.like("%" + keyword + "%")
+                        .or(location.sgg.like("%" + keyword + "%"))
+                        .or(location.emdg.like("%" + keyword + "%")))
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+        List<LocationDto> content = fetchResult.stream()
+                .map(LocationDto::from)
+                .toList();
+
+        Long count = queryFactory.select(location.count())
+                .from(location)
+                .where(location.sido.like("%" + keyword + "%")
+                        .or(location.sgg.like("%" + keyword + "%"))
+                        .or(location.emdg.like("%" + keyword + "%")))
+                .fetchOne();
+        assert count != null;
+
+        return new PageImpl<>(content, pageable, count);
+    }
+}

--- a/src/main/java/com/zelusik/eatery/service/AppleOAuthService.java
+++ b/src/main/java/com/zelusik/eatery/service/AppleOAuthService.java
@@ -3,8 +3,8 @@ package com.zelusik.eatery.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.zelusik.eatery.dto.auth.AppleOAuthPublicKey;
-import com.zelusik.eatery.dto.auth.AppleOAuthUserInfo;
+import com.zelusik.eatery.dto.apple.AppleOAuthPublicKey;
+import com.zelusik.eatery.dto.apple.AppleOAuthUserResponse;
 import com.zelusik.eatery.exception.auth.AppleOAuthLoginException;
 import com.zelusik.eatery.exception.auth.TokenValidateException;
 import io.jsonwebtoken.Claims;
@@ -48,7 +48,7 @@ public class AppleOAuthService {
      * @param identityToken 회원 정보가 담긴 identity token
      * @return 회원 정보
      */
-    public AppleOAuthUserInfo getUserInfo(String identityToken) {
+    public AppleOAuthUserResponse getUserInfo(String identityToken) {
         Map<String, Object> headerOfIdentityToken;
         try {
             headerOfIdentityToken = new ObjectMapper().readValue(
@@ -73,7 +73,7 @@ public class AppleOAuthService {
             throw new TokenValidateException(ex);
         }
 
-        return AppleOAuthUserInfo.from(claims);
+        return AppleOAuthUserResponse.from(claims);
     }
 
     /**

--- a/src/main/java/com/zelusik/eatery/service/HttpRequestService.java
+++ b/src/main/java/com/zelusik/eatery/service/HttpRequestService.java
@@ -1,5 +1,6 @@
 package com.zelusik.eatery.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -8,8 +9,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+@RequiredArgsConstructor
 @Service
 public class HttpRequestService {
+
+    private final RestTemplate restTemplate;
 
     /**
      * 외부 server에 HTTP request를 보낸다.
@@ -21,7 +25,7 @@ public class HttpRequestService {
      */
     public ResponseEntity<String> sendHttpRequest(String requestUrl, HttpMethod httpMethod, HttpHeaders headers) {
         HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
-        return new RestTemplate().exchange(
+        return restTemplate.exchange(
                 requestUrl,
                 httpMethod,
                 kakaoUserInfoRequest,

--- a/src/main/java/com/zelusik/eatery/service/HttpRequestService.java
+++ b/src/main/java/com/zelusik/eatery/service/HttpRequestService.java
@@ -1,6 +1,8 @@
 package com.zelusik.eatery.service;
 
+import com.zelusik.eatery.log.LogUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -9,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class HttpRequestService {
@@ -25,6 +28,9 @@ public class HttpRequestService {
      */
     public ResponseEntity<String> sendHttpRequest(String requestUrl, HttpMethod httpMethod, HttpHeaders headers) {
         HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
+
+        log.info("[{}] Send http request with uri={}, method={}, headers={}", LogUtils.getLogTraceId(), requestUrl, httpMethod, headers);
+
         return restTemplate.exchange(
                 requestUrl,
                 httpMethod,

--- a/src/main/java/com/zelusik/eatery/service/KakaoService.java
+++ b/src/main/java/com/zelusik/eatery/service/KakaoService.java
@@ -1,13 +1,11 @@
 package com.zelusik.eatery.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zelusik.eatery.dto.exception.ErrorResponse;
 import com.zelusik.eatery.dto.kakao.KakaoOAuthUserResponse;
 import com.zelusik.eatery.dto.kakao.KakaoPlaceResponse;
 import com.zelusik.eatery.exception.kakao.KakaoServerException;
 import com.zelusik.eatery.exception.kakao.KakaoTokenValidateException;
+import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
@@ -22,23 +20,17 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+@RequiredArgsConstructor
 @Service
 public class KakaoService {
 
-    private final ObjectMapper objectMapper;
     private final HttpRequestService httpRequestService;
 
     @Value("${kakao.rest-api.key}")
     private String apiKey;
-
-    public KakaoService(HttpRequestService httpRequestService) {
-        this.objectMapper = new ObjectMapper();
-        this.httpRequestService = httpRequestService;
-    }
 
     public KakaoOAuthUserResponse getUserInfo(String accessToken) {
         String requestUrl = "https://kapi.kakao.com/v2/user/me";
@@ -64,15 +56,7 @@ public class KakaoService {
             throw new KakaoServerException(HttpStatus.INTERNAL_SERVER_ERROR, errorDetails.code(), errorDetails.message(), ex);
         }
 
-        // Response의 body에서 user info 추출
-        Map<String, Object> attributes;
-        try {
-            attributes = objectMapper.readValue(response.getBody(), new TypeReference<>() {
-            });
-        } catch (JsonProcessingException e) {
-            attributes = Collections.emptyMap();
-        }
-
+        Map<String, Object> attributes = new JSONObject(response.getBody()).toMap();
         return KakaoOAuthUserResponse.from(attributes);
     }
 

--- a/src/main/java/com/zelusik/eatery/service/KakaoService.java
+++ b/src/main/java/com/zelusik/eatery/service/KakaoService.java
@@ -3,7 +3,7 @@ package com.zelusik.eatery.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.zelusik.eatery.dto.auth.KakaoOAuthUserInfo;
+import com.zelusik.eatery.dto.kakao.KakaoOAuthUserResponse;
 import com.zelusik.eatery.dto.exception.ErrorResponse;
 import com.zelusik.eatery.exception.kakao.KakaoServerException;
 import com.zelusik.eatery.exception.kakao.KakaoTokenValidateException;
@@ -29,7 +29,7 @@ public class KakaoService {
         this.httpRequestService = httpRequestService;
     }
 
-    public KakaoOAuthUserInfo getUserInfo(String accessToken) {
+    public KakaoOAuthUserResponse getUserInfo(String accessToken) {
         String requestUrl = "https://kapi.kakao.com/v2/user/me";
 
         // HTTP header 생성
@@ -62,7 +62,7 @@ public class KakaoService {
             attributes = Collections.emptyMap();
         }
 
-        return KakaoOAuthUserInfo.from(attributes);
+        return KakaoOAuthUserResponse.from(attributes);
     }
 
     private ErrorResponse getErrorDetails(Exception ex) {

--- a/src/main/java/com/zelusik/eatery/service/KakaoService.java
+++ b/src/main/java/com/zelusik/eatery/service/KakaoService.java
@@ -19,12 +19,12 @@ import java.util.Collections;
 import java.util.Map;
 
 @Service
-public class KakaoOAuthService {
+public class KakaoService {
 
     private final ObjectMapper objectMapper;
     private final HttpRequestService httpRequestService;
 
-    public KakaoOAuthService(HttpRequestService httpRequestService) {
+    public KakaoService(HttpRequestService httpRequestService) {
         this.objectMapper = new ObjectMapper();
         this.httpRequestService = httpRequestService;
     }

--- a/src/main/java/com/zelusik/eatery/service/KakaoService.java
+++ b/src/main/java/com/zelusik/eatery/service/KakaoService.java
@@ -10,7 +10,6 @@ import com.zelusik.eatery.exception.kakao.KakaoServerException;
 import com.zelusik.eatery.exception.kakao.KakaoTokenValidateException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -26,8 +25,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static com.zelusik.eatery.constant.ConstantUtil.PAGE_SIZE_OF_SEARCHING_MEETING_PLACES;
 
 @Service
 public class KakaoService {
@@ -82,8 +79,8 @@ public class KakaoService {
     /**
      * Kakao api를 활용해 키워드에 해당하는 지하철역, 관광명소, 학교를 검색한다.
      *
-     * @param keyword 검색 키워드
-     * @param page    page 번호. 1부터 시작한다.
+     * @param keyword  검색 키워드
+     * @param pageable paging 정보
      * @return 검색 결과
      * @see <a href="https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-keyword">Kakao developers - 키워드로 장소 검색하기</a>
      */

--- a/src/main/java/com/zelusik/eatery/service/LocationService.java
+++ b/src/main/java/com/zelusik/eatery/service/LocationService.java
@@ -1,0 +1,28 @@
+package com.zelusik.eatery.service;
+
+import com.zelusik.eatery.dto.location.LocationDto;
+import com.zelusik.eatery.repository.location.LocationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class LocationService {
+
+    private final LocationRepository locationRepository;
+
+    /**
+     * sido, sgg, emdg에 <code>keyword</code>가 포함된 location들을 조회한다.
+     *
+     * @param keyword  검색 키워드
+     * @param pageable paging 정보
+     * @return 조회된 location dtos
+     */
+    public Page<LocationDto> searchDtosByKeyword(String keyword, Pageable pageable) {
+        return locationRepository.searchDtosByKeyword(keyword, pageable);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
     multipart:
       max-request-size: 50MB
       max-file-size: 5MB
+  redis:
+    host: localhost
+    port: 6379
   jpa:
     open-in-view: false
     properties:
@@ -49,9 +52,6 @@ spring:
     username: ${EATERY_LOCAL_DB_USERNAME}
     password: ${EATERY_LOCAL_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-  redis:
-    host: localhost
-    port: 6379
   jpa:
     hibernate.ddl-auto: update
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,5 @@
 eatery.app.version: v.0.0.1
+kakao.rest-api.key: { KAKAO_REST-API_KEY }
 
 logging:
   level:

--- a/src/test/java/com/zelusik/eatery/controller/MeetingPlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/controller/MeetingPlaceControllerTest.java
@@ -1,0 +1,195 @@
+package com.zelusik.eatery.controller;
+
+import com.zelusik.eatery.config.SecurityConfig;
+import com.zelusik.eatery.constant.place.KakaoCategoryGroupCode;
+import com.zelusik.eatery.domain.place.Point;
+import com.zelusik.eatery.dto.kakao.KakaoPlaceResponse;
+import com.zelusik.eatery.dto.location.LocationDto;
+import com.zelusik.eatery.security.JwtAuthenticationFilter;
+import com.zelusik.eatery.security.UserPrincipal;
+import com.zelusik.eatery.service.KakaoService;
+import com.zelusik.eatery.service.LocationService;
+import com.zelusik.eatery.util.MemberTestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static com.zelusik.eatery.constant.ConstantUtil.PAGE_SIZE_OF_SEARCHING_MEETING_PLACES;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("[Controller] Meeting Place")
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(
+        controllers = MeetingPlaceController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {SecurityConfig.class, JwtAuthenticationFilter.class}
+        )
+)
+class MeetingPlaceControllerTest {
+
+    @MockBean
+    private LocationService locationService;
+    @MockBean
+    private KakaoService kakaoService;
+
+    private final MockMvc mvc;
+
+    public MeetingPlaceControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("검색 키워드와 15개의 location 객체가 결과로 주어지고, 키워드로 장소를 검색하면, 검색된 장소들을 반환한다.")
+    @Test
+    void givenKeywordAnd15LocationsAsResult_whenSearchingByKeyword_thenReturnPlaces() throws Exception {
+        // given
+        long memberId = 1L;
+        String keyword = "서울";
+        Pageable pageable = Pageable.ofSize(PAGE_SIZE_OF_SEARCHING_MEETING_PLACES);
+        PageImpl<LocationDto> expectedResult = new PageImpl<>(List.of(
+                LocationDto.of("서울특별시", "강동구", "암사제1동", new Point("", "127.132663")),
+                LocationDto.of("서울특별시", "종로구", "숭인동", new Point("", "127.0156274")),
+                LocationDto.of("서울특별시", "서초구", "방배2동", new Point("", "126.9855106")),
+                LocationDto.of("서울특별시", "종로구", "연지동", new Point("", "127.0002")),
+                LocationDto.of("서울특별시", "중구", "남대문로4가", new Point("", "126.975609")),
+                LocationDto.of("서울특별시", "동대문구", "전농제2동", new Point("", "127.0600375")),
+                LocationDto.of("서울특별시", "영등포구", "신길동", new Point("", "126.9214285")),
+                LocationDto.of("서울특별시", "동작구", "상도1동", new Point("", "126.953089")),
+                LocationDto.of("서울특별시", "종로구", "신교동", new Point("", "126.9678")),
+                LocationDto.of("서울특별시", "종로구", "신영동", new Point("", "126.9621")),
+                LocationDto.of("서울특별시", "양천구", "신정6동", new Point("", "126.8644471")),
+                LocationDto.of("서울특별시", "용산구", "원효로2가", new Point("", "126.963225")),
+                LocationDto.of("서울특별시", "영등포구", "양평제2동", new Point("", "126.8939535")),
+                LocationDto.of("서울특별시", "종로구", "사직동", new Point("", "126.9688397")),
+                LocationDto.of("서울특별시", "서대문구", "대신동", new Point("", "126.9459748"))
+        ));
+        given(locationService.searchDtosByKeyword(keyword, pageable)).willReturn(expectedResult);
+
+        // when & then
+        mvc.perform(
+                        get("/api/meeting-places")
+                                .queryParam("page", "0")
+                                .queryParam("keyword", keyword)
+                                .with(csrf())
+                                .with(user(UserPrincipal.of(MemberTestUtils.createMemberDtoWithId(memberId))))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.number").value(0))
+                .andExpect(jsonPath("$.size").value(15))
+                .andExpect(jsonPath("$.numOfElements").value(15))
+                .andExpect(jsonPath("$.contents").isArray())
+                .andExpect(jsonPath("$.contents").isNotEmpty());
+    }
+
+    @DisplayName("검색 키워드와 15개의 kakao 장소 데이터가 결과로 주어지고, 키워드로 장소를 검색하면, 검색된 장소들을 반환한다.")
+    @Test
+    void givenKeywordAnd15KakaoPlacesAsResult_whenSearchingByKeyword_thenReturnPlaces() throws Exception {
+        // given
+        long memberId = 1L;
+        String keyword = "광교";
+        Pageable pageable = Pageable.ofSize(PAGE_SIZE_OF_SEARCHING_MEETING_PLACES);
+        List<KakaoPlaceResponse> expectedContent = List.of(
+                KakaoPlaceResponse.of("광교역 신분당선", null, "http://place.map.kakao.com/27392590", "교통,수송 > 지하철,전철 > 신분당선", "경기 수원시 영통구 이의동 740-1", "경기 수원시 영통구 대학로 55", "27392590", "031-8018-7830", KakaoCategoryGroupCode.SW8, "127.044268853097", ""),
+                KakaoPlaceResponse.of("광교저수지", null, "http://place.map.kakao.com/11034070", "여행 > 관광,명소 > 저수지", "경기 수원시 장안구 하광교동 351", "", "11034070", "", KakaoCategoryGroupCode.AT4, "127.02853807770109", ""),
+                KakaoPlaceResponse.of("광교중앙역 신분당선", null, "http://place.map.kakao.com/27392591", "교통,수송 > 지하철,전철 > 신분당선", "경기 수원시 영통구 이의동 268-1", "경기 수원시 영통구 도청로 지하 45", "27392591", "031-8018-7820", KakaoCategoryGroupCode.SW8, "127.051726324729", ""),
+                KakaoPlaceResponse.of("광교카페거리", null, "http://place.map.kakao.com/24535871", "여행 > 관광,명소 > 테마거리 > 카페거리", "경기 수원시 영통구 이의동 1381-4", "", "24535871", "", KakaoCategoryGroupCode.AT4, "127.051874100004", ""),
+                KakaoPlaceResponse.of("광교마루길", null, "http://place.map.kakao.com/27610056", "여행 > 관광,명소 > 테마거리", "경기 수원시 장안구 하광교동", "", "27610056", "", KakaoCategoryGroupCode.AT4, "127.031979036898", ""),
+                KakaoPlaceResponse.of("광교호수공원 프라이부르크전망대", null, "http://place.map.kakao.com/381494312", "여행 > 관광,명소 > 전망대", "경기 수원시 영통구 하동 1024", "경기 수원시 영통구 광교호수로 127", "381494312", "070-8800-2460", KakaoCategoryGroupCode.AT4, "127.065981860276", ""),
+                KakaoPlaceResponse.of("광교고등학교", null, "http://place.map.kakao.com/14882947", "교육,학문 > 학교 > 고등학교", "경기 수원시 영통구 이의동 1346", "경기 수원시 영통구 도청로89번길 11", "14882947", "031-8061-8295", KakaoCategoryGroupCode.SC4, "127.04823999349", ""),
+                KakaoPlaceResponse.of("광교중학교", null, "http://place.map.kakao.com/12802018", "교육,학문 > 학교 > 중학교", "경기 수원시 영통구 이의동 1207", "경기 수원시 영통구 웰빙타운로 55", "12802018", "031-218-3520", KakaoCategoryGroupCode.SC4, "127.044721440604", ""),
+                KakaoPlaceResponse.of("광교어린이천문대", null, "http://place.map.kakao.com/854046920", "여행 > 관광,명소 > 천문대", "경기 수원시 영통구 이의동 1222-4", "경기 수원시 영통구 웰빙타운로36번길 46-248", "854046920", "031-216-3245", KakaoCategoryGroupCode.AT4, "127.05458522621", ""),
+                KakaoPlaceResponse.of("광교호수중학교", null, "http://place.map.kakao.com/1163650833", "교육,학문 > 학교 > 중학교", "경기 수원시 영통구 원천동 596", "경기 수원시 영통구 월드컵로 8", "1163650833", "031-895-2800", KakaoCategoryGroupCode.SC4, "127.0637536780756", ""),
+                KakaoPlaceResponse.of("광교초등학교", null, "http://place.map.kakao.com/12802084", "교육,학문 > 학교 > 초등학교", "경기 수원시 영통구 이의동 1208", "경기 수원시 영통구 대학로 91", "12802084", "031-217-7605", KakaoCategoryGroupCode.SC4, "127.04575876305618", ""),
+                KakaoPlaceResponse.of("광교호수초등학교", null, "http://place.map.kakao.com/1439712290", "교육,학문 > 학교 > 초등학교", "경기 수원시 영통구 원천동 589-1", "경기 수원시 영통구 광교호수공원로 205", "1439712290", "031-201-1700", KakaoCategoryGroupCode.SC4, "127.05879256113157", ""),
+                KakaoPlaceResponse.of("광교외식타운", null, "http://place.map.kakao.com/24829635", "여행 > 관광,명소 > 테마거리 > 먹자골목", "경기 수원시 영통구 이의동 1222-1", "경기 수원시 영통구 웰빙타운로36번길 46-220", "24829635", "", KakaoCategoryGroupCode.AT4, "127.054680109648", ""),
+                KakaoPlaceResponse.of("광교저수지", null, "http://place.map.kakao.com/1927266944", "여행 > 관광,명소 > 저수지", "경기 수원시 장안구 상광교동 411", "", "1927266944", "", KakaoCategoryGroupCode.AT4, "127.020951966686", ""),
+                KakaoPlaceResponse.of("광교골", null, "http://place.map.kakao.com/25181435", "여행 > 관광,명소 > 계곡", "경기 수원시 장안구 상광교동", "", "25181435", "", KakaoCategoryGroupCode.AT4, "127.015843158688", "")
+        );
+        given(locationService.searchDtosByKeyword(keyword, pageable)).willReturn(Page.empty());
+        given(kakaoService.searchKakaoPlacesByKeyword(keyword, pageable)).willReturn(new SliceImpl<>(expectedContent, pageable, false));
+
+        // when & then
+        mvc.perform(
+                        get("/api/meeting-places")
+                                .queryParam("page", "0")
+                                .queryParam("keyword", keyword)
+                                .with(csrf())
+                                .with(user(UserPrincipal.of(MemberTestUtils.createMemberDtoWithId(memberId))))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.number").value(0))
+                .andExpect(jsonPath("$.size").value(15))
+                .andExpect(jsonPath("$.numOfElements").value(15))
+                .andExpect(jsonPath("$.contents").isArray())
+                .andExpect(jsonPath("$.contents").isNotEmpty());
+    }
+
+    @DisplayName("검색 키워드와 함께 5개의 locations, 15개의 kakao 장소 데이터가 결과로 주어지고, 키워드로 장소를 검색하면, 검색된 장소들을 반환한다.")
+    @Test
+    void givenKeywordAnd3LocationsAnd15KakaoPlacesAsResult_whenSearchingByKeyword_thenReturnPlaces() throws Exception {
+        // given
+        long memberId = 1L;
+        String keyword = "수원";
+        Pageable pageable = Pageable.ofSize(PAGE_SIZE_OF_SEARCHING_MEETING_PLACES);
+        PageImpl<LocationDto> locations = new PageImpl<>(
+                List.of(LocationDto.of("경기도", "수원시", null, new Point("37.263476", "127.028646")),
+                        LocationDto.of("경기도", "수원시", "영통구", new Point("37.2596", "127.046525")),
+                        LocationDto.of("경기도", "수원시", "팔달구", new Point("37.2825695", "127.0200976")),
+                        LocationDto.of("경기도", "수원시", "권선구", new Point("37.257687", "126.971911")),
+                        LocationDto.of("경기도", "수원시", "장안구", new Point("37.3039709", "127.0101225")))
+        );
+        SliceImpl<KakaoPlaceResponse> kakaoPlaces = new SliceImpl<>(
+                List.of(KakaoPlaceResponse.of("서울대학교 수원수목원", null, "http://place.map.kakao.com/26624264", "여행 > 관광,명소 > 수목원,식물원", "경기 수원시 권선구 서둔동 92-6", "경기 수원시 권선구 서호로 16", "26624264", "", KakaoCategoryGroupCode.AT4, "126.982751815127", "37.2622966122058"),
+                        KakaoPlaceResponse.of("수원팔색길 화성성곽길", null, "http://place.map.kakao.com/26564541", "여행 > 관광,명소 > 도보여행 > 수원팔색길", "경기 수원시 장안구 연무동", "", "26564541", "", KakaoCategoryGroupCode.AT4, "127.0187965332498", "37.28706778274413"),
+                        KakaoPlaceResponse.of("일월저수지", null, "http://place.map.kakao.com/8058151", "여행 > 관광,명소 > 저수지", "경기 수원시 장안구 천천동", "", "8058151", "", KakaoCategoryGroupCode.AT4, "126.972831001286", "37.2882014656875"),
+                        KakaoPlaceResponse.of("광교산산림욕장", null, "http://place.map.kakao.com/11475391", "여행 > 관광,명소 > 자연휴양림", "경기 수원시 장안구 조원동 산 6", "", "11475391", "031-228-4575", KakaoCategoryGroupCode.AT4, "127.021603970425", "37.3088399610759"),
+                        KakaoPlaceResponse.of("광교호수공원 프라이부르크전망대", null, "http://place.map.kakao.com/381494312", "여행 > 관광,명소 > 전망대", "경기 수원시 영통구 하동 1024", "경기 수원시 영통구 광교호수로 127", "381494312", "070-8800-2460", KakaoCategoryGroupCode.AT4, "127.065981860276", "37.2806472011191"),
+                        KakaoPlaceResponse.of("서호", null, "http://place.map.kakao.com/11141835", "여행 > 관광,명소 > 저수지", "경기 수원시 팔달구 화서동", "", "11141835", "", KakaoCategoryGroupCode.AT4, "126.987890079534", "37.2771031598479"),
+                        KakaoPlaceResponse.of("수원공방거리", null, "http://place.map.kakao.com/27445985", "여행 > 관광,명소 > 테마거리", "경기 수원시 팔달구 남창동", "", "27445985", "", KakaoCategoryGroupCode.AT4, "127.015335023514", "37.2785877000022"),
+                        KakaoPlaceResponse.of("신대호수", null, "http://place.map.kakao.com/11740028", "여행 > 관광,명소 > 호수", "경기 수원시 영통구 하동", "", "11740028", "", KakaoCategoryGroupCode.AT4, "127.073864045742", "37.2866425637606"),
+                        KakaoPlaceResponse.of("원천호수", null, "http://place.map.kakao.com/8473582", "여행 > 관광,명소 > 호수", "경기 수원시 영통구 하동", "", "8473582", "", KakaoCategoryGroupCode.AT4, "127.063203398409", "37.2792494027177"),
+                        KakaoPlaceResponse.of("화서역먹자골목", null, "http://place.map.kakao.com/27469648", "여행 > 관광,명소 > 테마거리 > 먹자골목", "경기 수원시 팔달구 화서동 697", "", "27469648", "", KakaoCategoryGroupCode.AT4, "126.988984571545", "37.2873246575744"),
+                        KakaoPlaceResponse.of("수원팔색길 여우길", null, "http://place.map.kakao.com/27598174", "여행 > 관광,명소 > 도보여행 > 수원팔색길", "경기 수원시 영통구 이의동 1378-27", "", "27598174", "", KakaoCategoryGroupCode.AT4, "127.04658754556398", "37.286955586735615"),
+                        KakaoPlaceResponse.of("만석공원 만석거", null, "http://place.map.kakao.com/17807777", "여행 > 관광,명소 > 저수지", "경기 수원시 장안구 송죽동 414", "", "17807777", "", KakaoCategoryGroupCode.AT4, "127.000956453782", "37.2999180684856"),
+                        KakaoPlaceResponse.of("포시즌힐링팜", null, "http://place.map.kakao.com/1176369644", "여행 > 관광,명소 > 관광농원", "경기 수원시 권선구 입북동 584", "", "1176369644", "031-227-3555", KakaoCategoryGroupCode.AT4, "126.957867807748", "37.2893179770889"),
+                        KakaoPlaceResponse.of("호매실카페거리", null, "http://place.map.kakao.com/304906995", "여행 > 관광,명소 > 테마거리 > 카페거리", "경기 수원시 권선구 호매실동 1425-1", "", "304906995", "", KakaoCategoryGroupCode.AT4, "126.943121248332", "37.2687284572022"),
+                        KakaoPlaceResponse.of("하광교소류지", null, "http://place.map.kakao.com/18347208", "여행 > 관광,명소 > 저수지", "경기 수원시 장안구 하광교동 1", "", "18347208", "", KakaoCategoryGroupCode.AT4, "127.027574855137", "37.324934793141")),
+                pageable,
+                true
+        );
+        given(locationService.searchDtosByKeyword(keyword, pageable)).willReturn(locations);
+        given(kakaoService.searchKakaoPlacesByKeyword(keyword, pageable)).willReturn(kakaoPlaces);
+
+        // when & then
+        mvc.perform(
+                        get("/api/meeting-places")
+                                .queryParam("page", "0")
+                                .queryParam("keyword", keyword)
+                                .with(csrf())
+                                .with(user(UserPrincipal.of(MemberTestUtils.createMemberDtoWithId(memberId))))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.number").value(0))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.numOfElements").value(20))
+                .andExpect(jsonPath("$.contents").isArray())
+                .andExpect(jsonPath("$.contents").isNotEmpty());
+    }
+}

--- a/src/test/java/com/zelusik/eatery/dto/auth/KakaoOAuthUserResponseTest.java
+++ b/src/test/java/com/zelusik/eatery/dto/auth/KakaoOAuthUserResponseTest.java
@@ -3,6 +3,7 @@ package com.zelusik.eatery.dto.auth;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zelusik.eatery.constant.member.Gender;
+import com.zelusik.eatery.dto.kakao.KakaoOAuthUserResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +15,7 @@ import java.util.Map;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @DisplayName("[DTO] Kakao 사용자 정보 응답 데이터 테스트")
-class KakaoOAuthUserInfoTest {
+class KakaoOAuthUserResponseTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @DisplayName("Kakao 인증 응답이 주어지면 KakaoOAuthInfo 객체로 변환한다.")
@@ -57,7 +58,7 @@ class KakaoOAuthUserInfoTest {
         });
 
         // when
-        KakaoOAuthUserInfo result = KakaoOAuthUserInfo.from(attributes);
+        KakaoOAuthUserResponse result = KakaoOAuthUserResponse.from(attributes);
 
         // then
         assertThat(result.getSocialUid()).isEqualTo("1234567890");
@@ -106,7 +107,7 @@ class KakaoOAuthUserInfoTest {
         });
 
         // when
-        KakaoOAuthUserInfo result = KakaoOAuthUserInfo.from(attributes);
+        KakaoOAuthUserResponse result = KakaoOAuthUserResponse.from(attributes);
 
         // then
         assertThat(result.getSocialUid()).isEqualTo("1234567890");

--- a/src/test/java/com/zelusik/eatery/dto/kakao/KakaoPlaceResponseTest.java
+++ b/src/test/java/com/zelusik/eatery/dto/kakao/KakaoPlaceResponseTest.java
@@ -1,0 +1,53 @@
+package com.zelusik.eatery.dto.kakao;
+
+import com.zelusik.eatery.constant.place.KakaoCategoryGroupCode;
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[DTO] Kakao 장소 정보 응답 데이터 테스트")
+class KakaoPlaceResponseTest {
+
+    @DisplayName("Kakao 장소 응답이 주어지면, KakaoPlaceResponse 객체로 변환한다.")
+    @Test
+    void givenKakaoPlaceResponse_whenInstantiating_thenConvertKakaoPlaceResponseObject() {
+        // given
+        String response = """
+                {
+                    "place_name": "카카오프렌즈 코엑스점",
+                    "distance": "418",
+                    "place_url": "http://place.map.kakao.com/26338954",
+                    "category_name": "가정,생활 > 문구,사무용품 > 디자인문구 > 카카오프렌즈",
+                    "address_name": "서울 강남구 삼성동 159",
+                    "road_address_name": "서울 강남구 영동대로 513",
+                    "id": "26338954",
+                    "phone": "02-6002-1880",
+                    "category_group_code": "AT4",
+                    "category_group_name": "관광명소",
+                    "x": "127.05902969025047",
+                    "y": "37.51207412593136"
+                }
+                """;
+        Map<String, Object> attributes = new JSONObject(response).toMap();
+
+        // when
+        KakaoPlaceResponse result = KakaoPlaceResponse.from(attributes);
+
+        // then
+        assertThat(result.getPlaceName()).isEqualTo("카카오프렌즈 코엑스점");
+        assertThat(result.getDistance()).isEqualTo(418);
+        assertThat(result.getPlaceUrl()).isEqualTo("http://place.map.kakao.com/26338954");
+        assertThat(result.getCategoryName()).isEqualTo("가정,생활 > 문구,사무용품 > 디자인문구 > 카카오프렌즈");
+        assertThat(result.getAddressName()).isEqualTo("서울 강남구 삼성동 159");
+        assertThat(result.getRoadAddressName()).isEqualTo("서울 강남구 영동대로 513");
+        assertThat(result.getId()).isEqualTo("26338954");
+        assertThat(result.getPhone()).isEqualTo("02-6002-1880");
+        assertThat(result.getCategoryGroupCode()).isEqualTo(KakaoCategoryGroupCode.AT4);
+        assertThat(result.getX()).isEqualTo("127.05902969025047");
+        assertThat(result.getY()).isEqualTo("37.51207412593136");
+    }
+}

--- a/src/test/java/com/zelusik/eatery/dto/place/response/MeetingPlaceResponseTest.java
+++ b/src/test/java/com/zelusik/eatery/dto/place/response/MeetingPlaceResponseTest.java
@@ -1,0 +1,62 @@
+package com.zelusik.eatery.dto.place.response;
+
+import com.zelusik.eatery.constant.place.KakaoCategoryGroupCode;
+import com.zelusik.eatery.domain.place.Point;
+import com.zelusik.eatery.dto.kakao.KakaoPlaceResponse;
+import com.zelusik.eatery.dto.location.LocationDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[DTO] 약속 장소 응답 데이터 테스트")
+class MeetingPlaceResponseTest {
+
+    @DisplayName("LocationDto 객체가 주어지면, MeetingPlaceResponse 객체로 변환한다.")
+    @Test
+    void givenLocationDtoObject_whenInstantiating_thenConvertMeetingPlaceResponseObject() {
+        // given
+        LocationDto locationDto = LocationDto.of(877L, "경기도", "수원시", null, new Point("37.263476", "127.028646"));
+
+        // when
+        MeetingPlaceResponse result = MeetingPlaceResponse.from(locationDto);
+
+        // then
+        assertThat(result.getName()).isEqualTo("수원시");
+        assertThat(result.getSido()).isEqualTo("경기도");
+        assertThat(result.getSgg()).isEqualTo("수원시");
+        assertThat(result.getEmd()).isEqualTo(null);
+        assertThat(result.getPoint().getLat()).isEqualTo("37.263476");
+        assertThat(result.getPoint().getLng()).isEqualTo("127.028646");
+    }
+
+    @DisplayName("KakaoPlaceResponse 객체가 주어지면, MeetingPlaceResponse 객체로 변환한다.")
+    @Test
+    void givenKakaoPlaceResponseObject_whenInstantiating_thenConvertMeetingPlaceResponseObject() {
+        // given
+        KakaoPlaceResponse kakaoPlaceResponse = KakaoPlaceResponse.of(
+                "카카오프렌즈 코엑스점",
+                418,
+                "http://place.map.kakao.com/26338954",
+                "가정,생활 > 문구,사무용품 > 디자인문구 > 카카오프렌즈",
+                "서울 강남구 삼성동 159",
+                "서울 강남구 영동대로 513",
+                "26338954",
+                "02-6002-1880",
+                KakaoCategoryGroupCode.AT4,
+                "127.05902969025047",
+                "37.51207412593136"
+        );
+
+        // when
+        MeetingPlaceResponse result = MeetingPlaceResponse.from(kakaoPlaceResponse);
+
+        // then
+        assertThat(result.getName()).isEqualTo("카카오프렌즈 코엑스점");
+        assertThat(result.getSido()).isEqualTo("서울");
+        assertThat(result.getSgg()).isEqualTo("강남구");
+        assertThat(result.getEmd()).isEqualTo("삼성동");
+        assertThat(result.getPoint().getLat()).isEqualTo("37.51207412593136");
+        assertThat(result.getPoint().getLng()).isEqualTo("127.05902969025047");
+    }
+}

--- a/src/test/java/com/zelusik/eatery/integration/repository/location/LocationRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/repository/location/LocationRepositoryTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("[Repository] Location")
+@DisplayName("[Integration] Location Repository")
 @Import(QuerydslConfig.class)
 @ActiveProfiles("test")
 @DataJpaTest

--- a/src/test/java/com/zelusik/eatery/integration/repository/location/LocationRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/repository/location/LocationRepositoryTest.java
@@ -1,9 +1,10 @@
-package com.zelusik.eatery.repository.location;
+package com.zelusik.eatery.integration.repository.location;
 
 import com.zelusik.eatery.config.QuerydslConfig;
 import com.zelusik.eatery.domain.Location;
 import com.zelusik.eatery.domain.place.Point;
 import com.zelusik.eatery.dto.location.LocationDto;
+import com.zelusik.eatery.repository.location.LocationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/zelusik/eatery/integration/repository/place/PlaceRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/repository/place/PlaceRepositoryTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 대한민국 북-남 거리 약 1,100km
  */
 
-@DisplayName("[Repository] Place")
+@DisplayName("[Integration] Place Repository")
 @ActiveProfiles("test")
 @Import(QuerydslConfig.class)
 @DataJpaTest

--- a/src/test/java/com/zelusik/eatery/integration/repository/place/PlaceRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/repository/place/PlaceRepositoryTest.java
@@ -1,10 +1,12 @@
-package com.zelusik.eatery.repository.place;
+package com.zelusik.eatery.integration.repository.place;
 
 import com.zelusik.eatery.config.QuerydslConfig;
 import com.zelusik.eatery.constant.place.DayOfWeek;
 import com.zelusik.eatery.domain.place.Place;
 import com.zelusik.eatery.domain.place.Point;
 import com.zelusik.eatery.dto.place.PlaceDtoWithImages;
+import com.zelusik.eatery.repository.place.OpeningHoursRepository;
+import com.zelusik.eatery.repository.place.PlaceRepository;
 import com.zelusik.eatery.util.PlaceTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/zelusik/eatery/integration/service/KakaoServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/service/KakaoServiceTest.java
@@ -1,6 +1,8 @@
-package com.zelusik.eatery.service;
+package com.zelusik.eatery.integration.service;
 
 import com.zelusik.eatery.dto.kakao.KakaoPlaceResponse;
+import com.zelusik.eatery.service.HttpRequestService;
+import com.zelusik.eatery.service.KakaoService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/zelusik/eatery/integration/service/KakaoServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/integration/service/KakaoServiceTest.java
@@ -15,6 +15,7 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import static com.zelusik.eatery.constant.ConstantUtil.PAGE_SIZE_OF_SEARCHING_MEETING_PLACES;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@DisplayName("[Integration] Kakao Service")
 @SpringBootTest(classes = {KakaoService.class, ObjectMapper.class, HttpRequestService.class, RestTemplate.class})
 class KakaoServiceTest {
 
@@ -27,7 +28,7 @@ class KakaoServiceTest {
         // given
 
         // when
-        Slice<KakaoPlaceResponse> kakaoPlaceResponses = sut.searchKakaoPlacesByKeyword("수원", PageRequest.of(1, PAGE_SIZE_OF_SEARCHING_MEETING_PLACES));
+        Slice<KakaoPlaceResponse> kakaoPlaceResponses = sut.searchKakaoPlacesByKeyword("서울", PageRequest.of(1, PAGE_SIZE_OF_SEARCHING_MEETING_PLACES));
 
         // then
         assertThat(kakaoPlaceResponses).isNotEmpty();

--- a/src/test/java/com/zelusik/eatery/repository/location/LocationRepositoryTest.java
+++ b/src/test/java/com/zelusik/eatery/repository/location/LocationRepositoryTest.java
@@ -1,0 +1,103 @@
+package com.zelusik.eatery.repository.location;
+
+import com.zelusik.eatery.config.QuerydslConfig;
+import com.zelusik.eatery.domain.Location;
+import com.zelusik.eatery.domain.place.Point;
+import com.zelusik.eatery.dto.location.LocationDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[Repository] Location")
+@Import(QuerydslConfig.class)
+@ActiveProfiles("test")
+@DataJpaTest
+class LocationRepositoryTest {
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @BeforeEach
+    void createLocations() {
+        List<Location> locations = List.of(
+                Location.of("서울특별시", "강동구", "암사제1동", new Point("37.551508", "127.132663")),
+                Location.of("서울특별시", "종로구", "숭인동", new Point("37.5778049", "127.0156274")),
+                Location.of("서울특별시", "서초구", "방배2동", new Point("37.4797439", "126.9855106")),
+                Location.of("서울특별시", "종로구", "연지동", new Point("37.5737", "127.0002")),
+                Location.of("서울특별시", "중구", "남대문로4가", new Point("37.5605942", "126.975609")),
+                Location.of("서울특별시", "동대문구", "전농제2동", new Point("37.5781027", "127.0600375")),
+                Location.of("서울특별시", "영등포구", "신길동", new Point("37.5112667", "126.9214285")),
+                Location.of("서울특별시", "동작구", "상도1동", new Point("37.4981", "126.953089")),
+                Location.of("서울특별시", "종로구", "신교동", new Point("37.5845", "126.9678")),
+                Location.of("서울특별시", "종로구", "신영동", new Point("37.60294", "126.9621")),
+                Location.of("서울특별시", "양천구", "신정6동", new Point("37.5170414", "126.8644471")),
+                Location.of("서울특별시", "용산구", "원효로2가", new Point("37.536775", "126.963225")),
+                Location.of("서울특별시", "영등포구", "양평제2동", new Point("37.5364739", "126.8939535")),
+                Location.of("서울특별시", "종로구", "사직동", new Point("37.576196", "126.9688397")),
+                Location.of("서울특별시", "서대문구", "대신동", new Point("37.565502", "126.9459748")),
+                Location.of("서울특별시", "용산구", "이태원제1동", new Point("37.5325225", "126.9950384")),
+                Location.of("서울특별시", "마포구", null, new Point("37.5663245", "126.901491")),
+                Location.of("서울특별시", "동대문구", "장안제1동", new Point("37.567842", "127.066375")),
+                Location.of("서울특별시", "송파구", "오륜동", new Point("37.515425", "127.1343")),
+                Location.of("서울특별시", "도봉구", "도봉제1동", new Point("37.6786913", "127.0434369"))
+        );
+        locationRepository.saveAll(locations);
+    }
+
+    @DisplayName("검색 키워드가 주어지고, 키워드로 검색하면, 검색 결과가 반환된다.")
+    @Test
+    void givenKeyword_whenSearchingByKeyword_thenReturnSearchResults() {
+        // given
+        String keyword = "종로";
+
+        // when
+        Page<LocationDto> result = locationRepository.searchDtosByKeyword(keyword, Pageable.ofSize(15));
+
+        System.out.println("result.getTotalPages() = " + result.getTotalPages());
+        System.out.println("result.getTotalElements() = " + result.getTotalElements());
+        System.out.println("result.getNumber() = " + result.getNumber());
+
+        // then
+        assertThat(result.getNumberOfElements()).isEqualTo(5);
+        assertThat(result.hasNext()).isFalse();
+        result.forEach(res -> assertThat(
+                res.getSido().contains(keyword)
+                        || res.getSgg().contains(keyword)
+                        || res.getEmdg().contains(keyword)
+        ).isTrue());
+    }
+
+    @DisplayName("검색 키워드가 주어지고, 키워드로 두 번째 페이지(page 1)를 검색하면, 검색 결과가 반환된다.")
+    @Test
+    void givenKeyword_whenSearchingSecondPageByKeyword_thenReturnSearchResults() {
+        // given
+        String keyword = "서울";
+
+        // when
+        Page<LocationDto> result = locationRepository.searchDtosByKeyword(keyword, PageRequest.of(1, 15));
+
+        System.out.println("result.getTotalPages() = " + result.getTotalPages());
+        System.out.println("result.getTotalElements() = " + result.getTotalElements());
+        System.out.println("result.getNumber() = " + result.getNumber());
+
+        // then
+        assertThat(result.getNumberOfElements()).isEqualTo(5);
+        assertThat(result.hasNext()).isFalse();
+        result.forEach(res -> assertThat(
+                res.getSido().contains(keyword)
+                        || res.getSgg().contains(keyword)
+                        || res.getEmdg().contains(keyword)
+        ).isTrue());
+    }
+}

--- a/src/test/java/com/zelusik/eatery/service/KakaoServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/service/KakaoServiceTest.java
@@ -1,0 +1,34 @@
+package com.zelusik.eatery.service;
+
+import com.zelusik.eatery.dto.kakao.KakaoPlaceResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.client.RestTemplate;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import static com.zelusik.eatery.constant.ConstantUtil.PAGE_SIZE_OF_SEARCHING_MEETING_PLACES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = {KakaoService.class, ObjectMapper.class, HttpRequestService.class, RestTemplate.class})
+class KakaoServiceTest {
+
+    @Autowired
+    private KakaoService sut;
+
+    @DisplayName("검색 키워드가 주어지고, 카카오에서 키워드로 장소들을 검색하면, 검색된 장소들이 반환된다.")
+    @Test
+    void givenKeyword_whenSearchingPlacesFromKakao_thenReturnSearchingResult() {
+        // given
+
+        // when
+        Slice<KakaoPlaceResponse> kakaoPlaceResponses = sut.searchKakaoPlacesByKeyword("수원", PageRequest.of(1, PAGE_SIZE_OF_SEARCHING_MEETING_PLACES));
+
+        // then
+        assertThat(kakaoPlaceResponses).isNotEmpty();
+        assertThat(kakaoPlaceResponses.hasNext()).isTrue();
+    }
+}

--- a/src/test/java/com/zelusik/eatery/service/LocationServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/service/LocationServiceTest.java
@@ -1,0 +1,55 @@
+package com.zelusik.eatery.service;
+
+import com.zelusik.eatery.domain.place.Point;
+import com.zelusik.eatery.dto.location.LocationDto;
+import com.zelusik.eatery.repository.location.LocationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("[Service] Location")
+@ExtendWith(MockitoExtension.class)
+class LocationServiceTest {
+
+    @InjectMocks
+    private LocationService sut;
+
+    @Mock
+    private LocationRepository locationRepository;
+
+    @DisplayName("검색 키워드가 주어지고, 검색하면, 검색된 location dto 객체들이 반환된다.")
+    @Test
+    void givenKeyword_whenSearchingByKeyword_thenReturnLocationDtos() {
+        // given
+        String keyword = "서울";
+        Pageable pageable = Pageable.ofSize(15);
+        List<LocationDto> expectedContents = List.of(
+                LocationDto.of("서울특별시", "강동구", "암사제1동", new Point("37.551508", "127.132663")),
+                LocationDto.of("서울특별시", "종로구", "숭인동", new Point("37.5778049", "127.0156274")),
+                LocationDto.of("서울특별시", "서초구", "방배2동", new Point("37.4797439", "126.9855106")),
+                LocationDto.of("서울특별시", "종로구", "연지동", new Point("37.5737", "127.0002")),
+                LocationDto.of("서울특별시", "중구", "남대문로4가", new Point("37.5605942", "126.975609"))
+        );
+        given(locationRepository.searchDtosByKeyword(keyword, pageable)).willReturn(new PageImpl<>(expectedContents));
+
+        // when
+        Page<LocationDto> actualResult = sut.searchDtosByKeyword(keyword, pageable);
+
+        // then
+        then(locationRepository).should().searchDtosByKeyword(keyword, pageable);
+        then(locationRepository).shouldHaveNoMoreInteractions();
+        assertThat(actualResult.getNumberOfElements()).isEqualTo(5);
+    }
+}

--- a/src/test/java/com/zelusik/eatery/unit/controller/MeetingPlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MeetingPlaceControllerTest.java
@@ -1,7 +1,8 @@
-package com.zelusik.eatery.controller;
+package com.zelusik.eatery.unit.controller;
 
 import com.zelusik.eatery.config.SecurityConfig;
 import com.zelusik.eatery.constant.place.KakaoCategoryGroupCode;
+import com.zelusik.eatery.controller.MeetingPlaceController;
 import com.zelusik.eatery.domain.place.Point;
 import com.zelusik.eatery.dto.kakao.KakaoPlaceResponse;
 import com.zelusik.eatery.dto.location.LocationDto;

--- a/src/test/java/com/zelusik/eatery/unit/controller/MeetingPlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MeetingPlaceControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("[Controller] Meeting Place")
+@DisplayName("[Unit] Meeting Place Controller")
 @MockBean(JpaMetamodelMappingContext.class)
 @WebMvcTest(
         controllers = MeetingPlaceController.class,

--- a/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
@@ -38,7 +38,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("[Controller] Member")
+@DisplayName("[Unit] Member Controller")
 @MockBean(JpaMetamodelMappingContext.class)
 @WebMvcTest(
         controllers = MemberController.class,

--- a/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/MemberControllerTest.java
@@ -1,8 +1,9 @@
-package com.zelusik.eatery.controller;
+package com.zelusik.eatery.unit.controller;
 
 import com.zelusik.eatery.config.SecurityConfig;
 import com.zelusik.eatery.constant.member.Gender;
 import com.zelusik.eatery.constant.review.MemberDeletionSurveyType;
+import com.zelusik.eatery.controller.MemberController;
 import com.zelusik.eatery.dto.member.request.FavoriteFoodCategoriesUpdateRequest;
 import com.zelusik.eatery.dto.member.request.MemberUpdateRequest;
 import com.zelusik.eatery.dto.member.request.TermsAgreeRequest;

--- a/src/test/java/com/zelusik/eatery/unit/controller/PlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/PlaceControllerTest.java
@@ -1,8 +1,9 @@
-package com.zelusik.eatery.controller;
+package com.zelusik.eatery.unit.controller;
 
 import com.zelusik.eatery.config.SecurityConfig;
 import com.zelusik.eatery.constant.place.FilteringType;
 import com.zelusik.eatery.constant.place.PlaceSearchKeyword;
+import com.zelusik.eatery.controller.PlaceController;
 import com.zelusik.eatery.dto.place.PlaceDtoWithImages;
 import com.zelusik.eatery.dto.place.PlaceFilteringKeywordDto;
 import com.zelusik.eatery.dto.place.request.PlaceCreateRequest;

--- a/src/test/java/com/zelusik/eatery/unit/controller/PlaceControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/PlaceControllerTest.java
@@ -40,7 +40,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("[Controller] Place")
+@DisplayName("[Unit] Place Controller")
 @MockBean(JpaMetamodelMappingContext.class)
 @WebMvcTest(
         controllers = PlaceController.class,

--- a/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DisplayName("[Controller] Review")
+@DisplayName("[Unit] Review Controller")
 @MockBean(JpaMetamodelMappingContext.class)
 @WebMvcTest(
         controllers = ReviewController.class,

--- a/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/controller/ReviewControllerTest.java
@@ -1,6 +1,7 @@
-package com.zelusik.eatery.controller;
+package com.zelusik.eatery.unit.controller;
 
 import com.zelusik.eatery.config.SecurityConfig;
+import com.zelusik.eatery.controller.ReviewController;
 import com.zelusik.eatery.dto.review.request.ReviewCreateRequest;
 import com.zelusik.eatery.service.ReviewService;
 import com.zelusik.eatery.security.JwtAuthenticationFilter;

--- a/src/test/java/com/zelusik/eatery/unit/service/FileServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/FileServiceTest.java
@@ -18,7 +18,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-@DisplayName("[Service] S3 File")
+@DisplayName("[Unit] S3 File Service")
 @ExtendWith(MockitoExtension.class)
 class FileServiceTest {
 

--- a/src/test/java/com/zelusik/eatery/unit/service/FileServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/FileServiceTest.java
@@ -1,9 +1,10 @@
-package com.zelusik.eatery.service;
+package com.zelusik.eatery.unit.service;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.zelusik.eatery.dto.file.S3FileDto;
+import com.zelusik.eatery.service.FileService;
 import com.zelusik.eatery.util.MultipartFileTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/zelusik/eatery/unit/service/JwtTokenServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/JwtTokenServiceTest.java
@@ -1,4 +1,4 @@
-package com.zelusik.eatery.service;
+package com.zelusik.eatery.unit.service;
 
 import com.zelusik.eatery.constant.member.LoginType;
 import com.zelusik.eatery.dto.auth.RedisRefreshToken;
@@ -7,6 +7,7 @@ import com.zelusik.eatery.repository.RedisRefreshTokenRepository;
 import com.zelusik.eatery.exception.auth.TokenValidateException;
 import com.zelusik.eatery.security.JwtTokenInfoDto;
 import com.zelusik.eatery.security.JwtTokenProvider;
+import com.zelusik.eatery.service.JwtTokenService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/zelusik/eatery/unit/service/JwtTokenServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/JwtTokenServiceTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 
-@DisplayName("[Service] JwtToken")
+@DisplayName("[Unit] JwtToken Service")
 @ExtendWith(MockitoExtension.class)
 class JwtTokenServiceTest {
 

--- a/src/test/java/com/zelusik/eatery/unit/service/KakaoServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/KakaoServiceTest.java
@@ -1,0 +1,291 @@
+package com.zelusik.eatery.unit.service;
+
+import com.zelusik.eatery.dto.kakao.KakaoPlaceResponse;
+import com.zelusik.eatery.service.HttpRequestService;
+import com.zelusik.eatery.service.KakaoService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import static com.zelusik.eatery.constant.ConstantUtil.PAGE_SIZE_OF_SEARCHING_MEETING_PLACES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("[Unit] Kakao Service")
+@ExtendWith(MockitoExtension.class)
+class KakaoServiceTest {
+
+    @InjectMocks
+    private KakaoService sut;
+
+    @Mock
+    private HttpRequestService httpRequestService;
+
+    @DisplayName("검색 키워드가 주어지고, 카카오에서 키워드로 장소들을 검색하면, 검색된 장소들이 반환된다.")
+    @Test
+    void givenKeyword_whenSearchingPlacesFromKakao_thenReturnSearchingResult() {
+        // given
+        String keyword = "서울";
+        Pageable pageable = Pageable.ofSize(PAGE_SIZE_OF_SEARCHING_MEETING_PLACES);
+        String requestUri = UriComponentsBuilder
+                .fromUriString("https://dapi.kakao.com/v2/local/search/keyword.json")
+                .queryParam("page", pageable.getPageNumber() + 1)
+                .queryParam("size", pageable.getPageSize())
+                .queryParam("category_group_code", "SW8,AT4,SC4")
+                .queryParam("query", keyword)
+                .build().toUriString();
+        given(httpRequestService.sendHttpRequest(eq(requestUri), eq(HttpMethod.GET), any(HttpHeaders.class)))
+                .willReturn(new ResponseEntity<>("""
+                        {
+                            "documents":[
+                                {
+                                    "address_name":"서울 용산구 이촌동 302-146",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 섬 > 섬(내륙)",
+                                    "distance":"",
+                                    "id":"8252248",
+                                    "phone":"02-749-4500",
+                                    "place_name":"노들섬",
+                                    "place_url":"http://place.map.kakao.com/8252248",
+                                    "road_address_name":"서울 용산구 양녕로 445",
+                                    "x":"126.95803386590158",
+                                    "y":"37.51766013568054"
+                                },
+                                {
+                                    "address_name":"서울 도봉구 방학동",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 도보여행 > 둘레길 > 북한산둘레길",
+                                    "distance":"",
+                                    "id":"18580965",
+                                    "phone":"",
+                                    "place_name":"북한산둘레길 왕실묘역길20구간",
+                                    "place_url":"http://place.map.kakao.com/18580965",
+                                    "road_address_name":"",
+                                    "x":"127.0186775926887",
+                                    "y":"37.661988874268154"
+                                },
+                                {
+                                    "address_name":"서울 종로구 와룡동 2-1",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 문화유적 > 고궁,궁",
+                                    "distance":"",
+                                    "id":"11156260",
+                                    "phone":"02-762-4868",
+                                    "place_name":"창경궁",
+                                    "place_url":"http://place.map.kakao.com/11156260",
+                                    "road_address_name":"서울 종로구 창경궁로 185",
+                                    "x":"126.995199911733",
+                                    "y":"37.5794165384496"
+                                },
+                                {
+                                    "address_name":"서울 강남구 신사동 668-33",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 테마거리",
+                                    "distance":"",
+                                    "id":"7990409",
+                                    "phone":"02-3445-6402",
+                                    "place_name":"압구정로데오거리",
+                                    "place_url":"http://place.map.kakao.com/7990409",
+                                    "road_address_name":"",
+                                    "x":"127.039152029523",
+                                    "y":"37.5267558230172"
+                                },
+                                {
+                                    "address_name":"서울 송파구 잠실동 47",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 호수",
+                                    "distance":"",
+                                    "id":"7947003",
+                                    "phone":"",
+                                    "place_name":"석촌호수 서호",
+                                    "place_url":"http://place.map.kakao.com/7947003",
+                                    "road_address_name":"",
+                                    "x":"127.099112837006",
+                                    "y":"37.5076807262772"
+                                },
+                                {
+                                    "address_name":"서울 종로구 관훈동",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 테마거리",
+                                    "distance":"",
+                                    "id":"8053121",
+                                    "phone":"",
+                                    "place_name":"인사동거리",
+                                    "place_url":"http://place.map.kakao.com/8053121",
+                                    "road_address_name":"",
+                                    "x":"126.98561901337",
+                                    "y":"37.5733610774662"
+                                },
+                                {
+                                    "address_name":"서울 영등포구 여의도동",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 강",
+                                    "distance":"",
+                                    "id":"13121007",
+                                    "phone":"",
+                                    "place_name":"한강",
+                                    "place_url":"http://place.map.kakao.com/13121007",
+                                    "road_address_name":"",
+                                    "x":"126.947545050571",
+                                    "y":"37.5250892160129"
+                                },
+                                {
+                                    "address_name":"서울 영등포구 여의도동",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 테마거리",
+                                    "distance":"",
+                                    "id":"8003939",
+                                    "phone":"",
+                                    "place_name":"여의서로",
+                                    "place_url":"http://place.map.kakao.com/8003939",
+                                    "road_address_name":"",
+                                    "x":"126.91493215270192",
+                                    "y":"37.53351080966769"
+                                },
+                                {
+                                    "address_name":"서울 성동구 응봉동",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 산",
+                                    "distance":"",
+                                    "id":"10666639",
+                                    "phone":"",
+                                    "place_name":"응봉산",
+                                    "place_url":"http://place.map.kakao.com/10666639",
+                                    "road_address_name":"",
+                                    "x":"127.029834156041",
+                                    "y":"37.5482528089186"
+                                },
+                                {
+                                    "address_name":"서울 마포구 서교동 348-78",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 테마거리",
+                                    "distance":"",
+                                    "id":"17169006",
+                                    "phone":"02-337-7361",
+                                    "place_name":"홍대패션거리",
+                                    "place_url":"http://place.map.kakao.com/17169006",
+                                    "road_address_name":"",
+                                    "x":"126.923580878826",
+                                    "y":"37.5553965854703"
+                                },
+                                {
+                                    "address_name":"서울 송파구 신천동 32",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 호수",
+                                    "distance":"",
+                                    "id":"27212955",
+                                    "phone":"",
+                                    "place_name":"석촌호수 동호",
+                                    "place_url":"http://place.map.kakao.com/27212955",
+                                    "road_address_name":"",
+                                    "x":"127.105899949393",
+                                    "y":"37.5116212351376"
+                                },
+                                {
+                                    "address_name":"서울 중구 명동2가",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 테마거리",
+                                    "distance":"",
+                                    "id":"7876521",
+                                    "phone":"",
+                                    "place_name":"명동거리",
+                                    "place_url":"http://place.map.kakao.com/7876521",
+                                    "road_address_name":"",
+                                    "x":"126.984901336292",
+                                    "y":"37.5620769169639"
+                                },
+                                {
+                                    "address_name":"서울 송파구 신천동 29",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 전망대",
+                                    "distance":"",
+                                    "id":"680691609",
+                                    "phone":"1661-2000",
+                                    "place_name":"서울스카이",
+                                    "place_url":"http://place.map.kakao.com/680691609",
+                                    "road_address_name":"서울 송파구 올림픽로 300",
+                                    "x":"127.102544369423",
+                                    "y":"37.5126729644342"
+                                },
+                                {
+                                    "address_name":"서울 성북구 삼선동1가",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 도보여행 > 서울한양도성",
+                                    "distance":"",
+                                    "id":"18741277",
+                                    "phone":"",
+                                    "place_name":"서울한양도성 낙산구간2코스",
+                                    "place_url":"http://place.map.kakao.com/18741277",
+                                    "road_address_name":"",
+                                    "x":"127.00863578989066",
+                                    "y":"37.58079664277135"
+                                },
+                                {
+                                    "address_name":"서울 광진구 능동 18",
+                                    "category_group_code":"AT4",
+                                    "category_group_name":"관광명소",
+                                    "category_name":"여행 > 관광,명소 > 동물원",
+                                    "distance":"",
+                                    "id":"17556470",
+                                    "phone":"02-450-9311",
+                                    "place_name":"서울어린이대공원 동물원",
+                                    "place_url":"http://place.map.kakao.com/17556470",
+                                    "road_address_name":"",
+                                    "x":"127.082318892024",
+                                    "y":"37.5482386958136"
+                                }
+                            ],
+                            "meta":{
+                                "is_end":false,
+                                "pageable_count":45,
+                                "same_name":{
+                                    "keyword":"",
+                                    "region":[
+                                       \s
+                                    ],
+                                    "selected_region":"서울특별시"
+                                },
+                                "total_count":2780
+                            }
+                        }
+                        """,
+                        HttpStatus.OK));
+
+        // when
+        Slice<KakaoPlaceResponse> result = sut.searchKakaoPlacesByKeyword(keyword, pageable);
+
+        // then
+        then(httpRequestService).should().sendHttpRequest(eq(requestUri), eq(HttpMethod.GET), any(HttpHeaders.class));
+        then(httpRequestService).shouldHaveNoMoreInteractions();
+        assertThat(result.getNumberOfElements()).isEqualTo(15);
+        assertThat(result.getContent()).isNotEmpty();
+        assertThat(result.hasNext()).isTrue();
+    }
+}

--- a/src/test/java/com/zelusik/eatery/unit/service/LocationServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/LocationServiceTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-@DisplayName("[Service] Location")
+@DisplayName("[Unit] Location Service")
 @ExtendWith(MockitoExtension.class)
 class LocationServiceTest {
 

--- a/src/test/java/com/zelusik/eatery/unit/service/LocationServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/LocationServiceTest.java
@@ -1,8 +1,9 @@
-package com.zelusik.eatery.service;
+package com.zelusik.eatery.unit.service;
 
 import com.zelusik.eatery.domain.place.Point;
 import com.zelusik.eatery.dto.location.LocationDto;
 import com.zelusik.eatery.repository.location.LocationRepository;
+import com.zelusik.eatery.service.LocationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/zelusik/eatery/unit/service/MemberServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/MemberServiceTest.java
@@ -1,4 +1,4 @@
-package com.zelusik.eatery.service;
+package com.zelusik.eatery.unit.service;
 
 import com.zelusik.eatery.constant.FoodCategory;
 import com.zelusik.eatery.constant.member.Gender;
@@ -16,6 +16,8 @@ import com.zelusik.eatery.repository.member.MemberRepository;
 import com.zelusik.eatery.repository.member.TermsInfoRepository;
 import com.zelusik.eatery.exception.member.MemberIdNotFoundException;
 import com.zelusik.eatery.exception.member.MemberNotFoundException;
+import com.zelusik.eatery.service.MemberService;
+import com.zelusik.eatery.service.ProfileImageService;
 import com.zelusik.eatery.util.MemberTestUtils;
 import com.zelusik.eatery.util.MultipartFileTestUtils;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/zelusik/eatery/unit/service/MemberServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/MemberServiceTest.java
@@ -40,7 +40,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.*;
 
-@DisplayName("[Service] Member")
+@DisplayName("[Unit] Member Service")
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 

--- a/src/test/java/com/zelusik/eatery/unit/service/PlaceServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/PlaceServiceTest.java
@@ -50,7 +50,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@DisplayName("[Service] Place")
+@DisplayName("[Unit] Place Service")
 @ExtendWith(MockitoExtension.class)
 class PlaceServiceTest {
 

--- a/src/test/java/com/zelusik/eatery/unit/service/PlaceServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/PlaceServiceTest.java
@@ -1,4 +1,4 @@
-package com.zelusik.eatery.service;
+package com.zelusik.eatery.unit.service;
 
 import com.zelusik.eatery.constant.place.DayOfWeek;
 import com.zelusik.eatery.constant.place.FilteringType;
@@ -16,6 +16,9 @@ import com.zelusik.eatery.repository.bookmark.BookmarkRepository;
 import com.zelusik.eatery.repository.place.OpeningHoursRepository;
 import com.zelusik.eatery.repository.place.PlaceRepository;
 import com.zelusik.eatery.repository.review.ReviewKeywordRepository;
+import com.zelusik.eatery.service.PlaceService;
+import com.zelusik.eatery.service.ReviewImageService;
+import com.zelusik.eatery.service.WebScrapingService;
 import com.zelusik.eatery.util.PlaceTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/zelusik/eatery/unit/service/ProfileImageServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/ProfileImageServiceTest.java
@@ -1,9 +1,11 @@
-package com.zelusik.eatery.service;
+package com.zelusik.eatery.unit.service;
 
 import com.zelusik.eatery.domain.member.Member;
 import com.zelusik.eatery.domain.member.ProfileImage;
 import com.zelusik.eatery.dto.ImageDto;
 import com.zelusik.eatery.repository.member.ProfileImageRepository;
+import com.zelusik.eatery.service.FileService;
+import com.zelusik.eatery.service.ProfileImageService;
 import com.zelusik.eatery.util.MemberTestUtils;
 import com.zelusik.eatery.util.MultipartFileTestUtils;
 import com.zelusik.eatery.util.S3FileTestUtils;

--- a/src/test/java/com/zelusik/eatery/unit/service/ProfileImageServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/ProfileImageServiceTest.java
@@ -25,7 +25,7 @@ import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@DisplayName("[Service] ProfileImage")
+@DisplayName("[Unit] ProfileImage Service")
 @ExtendWith(MockitoExtension.class)
 class ProfileImageServiceTest {
 

--- a/src/test/java/com/zelusik/eatery/unit/service/ReviewImageServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/ReviewImageServiceTest.java
@@ -24,7 +24,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@DisplayName("[Service] Review File")
+@DisplayName("[Unit] Review File Service")
 @ExtendWith(MockitoExtension.class)
 class ReviewImageServiceTest {
 

--- a/src/test/java/com/zelusik/eatery/unit/service/ReviewImageServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/ReviewImageServiceTest.java
@@ -1,8 +1,10 @@
-package com.zelusik.eatery.service;
+package com.zelusik.eatery.unit.service;
 
 import com.zelusik.eatery.domain.review.Review;
 import com.zelusik.eatery.dto.ImageDto;
 import com.zelusik.eatery.repository.review.ReviewImageRepository;
+import com.zelusik.eatery.service.FileService;
+import com.zelusik.eatery.service.ReviewImageService;
 import com.zelusik.eatery.util.MultipartFileTestUtils;
 import com.zelusik.eatery.util.ReviewTestUtils;
 import com.zelusik.eatery.util.S3FileTestUtils;

--- a/src/test/java/com/zelusik/eatery/unit/service/ReviewServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/ReviewServiceTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 
-@DisplayName("[Service] Review")
+@DisplayName("[Unit] Review Service")
 @ExtendWith(MockitoExtension.class)
 class ReviewServiceTest {
 

--- a/src/test/java/com/zelusik/eatery/unit/service/ReviewServiceTest.java
+++ b/src/test/java/com/zelusik/eatery/unit/service/ReviewServiceTest.java
@@ -1,4 +1,4 @@
-package com.zelusik.eatery.service;
+package com.zelusik.eatery.unit.service;
 
 import com.zelusik.eatery.constant.review.ReviewKeywordValue;
 import com.zelusik.eatery.domain.member.Member;
@@ -12,6 +12,10 @@ import com.zelusik.eatery.repository.bookmark.BookmarkRepository;
 import com.zelusik.eatery.repository.review.ReviewKeywordRepository;
 import com.zelusik.eatery.repository.review.ReviewRepository;
 import com.zelusik.eatery.exception.review.ReviewDeletePermissionDeniedException;
+import com.zelusik.eatery.service.MemberService;
+import com.zelusik.eatery.service.PlaceService;
+import com.zelusik.eatery.service.ReviewImageService;
+import com.zelusik.eatery.service.ReviewService;
 import com.zelusik.eatery.util.MemberTestUtils;
 import com.zelusik.eatery.util.MultipartFileTestUtils;
 import com.zelusik.eatery.util.PlaceTestUtils;


### PR DESCRIPTION
## 🔥 Related Issue
- Close #166

## 🏃‍ Task
- 행정주소와 그 좌표를 함께 저장할 `Location` entity class 구현
- Kakao local api 호출을 위해 설정에 kakao rest api key 추가
- `JSON`, `Gson` dependency 추가
- `RestTemplate`을 일일히 생성하는 것이 아닌 Spring container에서 singleton으로 관리하도록 로직 변경
- 약속장소 검색 기능 구현 
- 기존에 `ObjectMapper`를 사용해 불편하게 json 형태의 응답을 java object로 변환하던 로직을 `JSONObject`와 `Gson`을 활용하여 개선

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?
